### PR TITLE
Add iCal import workflow and local calendar support

### DIFF
--- a/docker/pi/Dockerfile
+++ b/docker/pi/Dockerfile
@@ -39,13 +39,17 @@ RUN apt-get update && \
       ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+RUN groupadd --system radicale \
+    && useradd --system --gid radicale --home-dir /var/lib/radicale --no-create-home radicale
+
 RUN python3 -m venv /opt/radicale \
     && /opt/radicale/bin/pip install --no-cache-dir --upgrade pip \
     && /opt/radicale/bin/pip install --no-cache-dir "radicale[bcrypt]" \
     && ln -s /opt/radicale/bin/radicale /usr/local/bin/radicale
 
 COPY docker/pi/radicale.config /etc/radicale/config
-RUN mkdir -p /var/lib/radicale/collections
+RUN mkdir -p /var/lib/radicale/collections \
+    && chown -R radicale:radicale /var/lib/radicale
 RUN mkdir -p /var/lib/fluidcalendar
 
 WORKDIR /app

--- a/docker/pi/Dockerfile
+++ b/docker/pi/Dockerfile
@@ -77,6 +77,10 @@ ENV POSTGRES_PORT=5432
 ENV RADICALE_USERNAME=fluid
 ENV RADICALE_PASSWORD=fluid
 ENV RADICALE_BASE_URL=http://localhost:5232
+ENV RADICALE_BIN=/opt/radicale/bin/radicale
+ENV RADICALE_LISTEN_HOST=127.0.0.1
+ENV RADICALE_LISTEN_PORT=5232
+ENV RADICALE_START_TIMEOUT=30
 ENV DATABASE_URL=postgresql://fluid:fluid@127.0.0.1:5432/fluid_calendar?schema=public
 
 ENTRYPOINT ["/usr/local/bin/pidev-entrypoint.sh"]

--- a/docker/pi/entrypoint.sh
+++ b/docker/pi/entrypoint.sh
@@ -18,6 +18,22 @@ RADICALE_LISTEN_HOST="${RADICALE_LISTEN_HOST:-127.0.0.1}"
 RADICALE_LISTEN_PORT="${RADICALE_LISTEN_PORT:-5232}"
 RADICALE_START_TIMEOUT="${RADICALE_START_TIMEOUT:-30}"
 RADICALE_LOG_FILE="${RADICALE_LOG_FILE:-${APP_STATE_DIR}/logs/radicale.log}"
+RADICALE_STORAGE_TYPE="${RADICALE_STORAGE_TYPE:-auto}"
+RADICALE_STORAGE_CANDIDATES="${RADICALE_STORAGE_CANDIDATES:-multifilesystem filesystem}"
+RADICALE_PYTHON_BIN="${RADICALE_PYTHON_BIN:-}"
+
+RADICALE_PYTHON="${RADICALE_PYTHON_BIN}"
+if [ -z "${RADICALE_PYTHON}" ]; then
+  local_candidate_python="$(dirname "${RADICALE_BIN}")/python"
+  if [ -x "${local_candidate_python}" ]; then
+    RADICALE_PYTHON="${local_candidate_python}"
+  else
+    RADICALE_PYTHON="python3"
+  fi
+elif [ ! -x "${RADICALE_PYTHON}" ]; then
+  echo "Configured RADICALE_PYTHON_BIN (${RADICALE_PYTHON}) is not executable. Falling back to python3." >&2
+  RADICALE_PYTHON="python3"
+fi
 
 APP_STATE_DIR="${APP_STATE_DIR:-/var/lib/fluidcalendar}"
 NEXTAUTH_SECRET_FILE="${NEXTAUTH_SECRET_FILE:-${APP_STATE_DIR}/nextauth_secret}"
@@ -156,6 +172,97 @@ if id "${RADICALE_RUN_USER}" >/dev/null 2>&1; then
   fi
   chown "${RADICALE_RUN_USER}:${RADICALE_RUN_GROUP}" "${RADICALE_LOG_FILE}"
   chmod 640 "${RADICALE_LOG_FILE}"
+fi
+
+configure_radicale_storage_backend() {
+  local -a candidate_types=()
+  if [ "${RADICALE_STORAGE_TYPE}" != "auto" ]; then
+    candidate_types=("${RADICALE_STORAGE_TYPE}")
+  elif [ -n "${RADICALE_STORAGE_CANDIDATES:-}" ]; then
+    # shellcheck disable=SC2206
+    candidate_types=(${RADICALE_STORAGE_CANDIDATES})
+  else
+    candidate_types=("multifilesystem" "filesystem")
+  fi
+
+  local selected_type=""
+  for candidate in "${candidate_types[@]}"; do
+    candidate="${candidate//[[:space:]]/}"
+    if [ -z "${candidate}" ]; then
+      continue
+    fi
+    if "${RADICALE_PYTHON}" - <<'PY' "${candidate}" >/dev/null 2>&1; then
+import importlib
+import sys
+
+module = sys.argv[1]
+try:
+    import radicale  # noqa: F401
+except ModuleNotFoundError:
+    raise SystemExit(2)
+
+try:
+    importlib.import_module(f"radicale.storage.{module}")
+except ModuleNotFoundError:
+    raise SystemExit(1)
+PY
+      selected_type="${candidate}"
+      break
+    fi
+  done
+
+  if [ -z "${selected_type}" ]; then
+    echo "Unable to locate a compatible Radicale storage backend. Checked candidates: ${candidate_types[*]}" >&2
+    "${RADICALE_PYTHON}" - <<'PY' 1>&2 || true
+import pkgutil
+
+try:
+    import radicale.storage
+except ModuleNotFoundError:
+    print("radicale package is not available in the selected interpreter.")
+    raise SystemExit(0)
+
+modules = sorted(name for _, name, _ in pkgutil.iter_modules(radicale.storage.__path__))
+if modules:
+    print("Discovered radicale.storage modules:", ", ".join(modules))
+else:
+    print("No modules found under radicale.storage.")
+PY
+    return 1
+  fi
+
+  if ! "${RADICALE_PYTHON}" - <<'PY' "${RADICALE_CONFIG}" "${selected_type}" "${RADICALE_STORAGE}"
+import configparser
+import sys
+
+config_path, storage_type, storage_dir = sys.argv[1:4]
+
+parser = configparser.ConfigParser()
+parser.read(config_path)
+
+if "storage" not in parser:
+    parser["storage"] = {}
+
+parser["storage"]["type"] = storage_type
+
+if storage_type.endswith("filesystem"):
+    parser["storage"]["filesystem_folder"] = storage_dir
+
+with open(config_path, "w", encoding="utf-8") as config_file:
+    parser.write(config_file)
+PY
+  then
+    echo "Failed to update Radicale configuration with storage backend ${selected_type}." >&2
+    return 1
+  fi
+
+  RADICALE_SELECTED_STORAGE_TYPE="${selected_type}"
+  echo "Configured Radicale storage backend '${RADICALE_SELECTED_STORAGE_TYPE}' with data root ${RADICALE_STORAGE}."
+}
+
+if ! configure_radicale_storage_backend; then
+  echo "Radicale storage configuration failed. Exiting." >&2
+  exit 1
 fi
 
 start_radicale() {

--- a/docker/pi/entrypoint.sh
+++ b/docker/pi/entrypoint.sh
@@ -11,6 +11,8 @@ RADICALE_PASSWORD="${RADICALE_PASSWORD:-fluid}"
 RADICALE_CONFIG="${RADICALE_CONFIG:-/etc/radicale/config}"
 RADICALE_USERS_FILE="${RADICALE_USERS_FILE:-/etc/radicale/users}"
 RADICALE_STORAGE="${RADICALE_STORAGE:-/var/lib/radicale/collections}"
+RADICALE_RUN_USER="${RADICALE_RUN_USER:-radicale}"
+RADICALE_RUN_GROUP="${RADICALE_RUN_GROUP:-${RADICALE_RUN_USER}}"
 
 APP_STATE_DIR="${APP_STATE_DIR:-/var/lib/fluidcalendar}"
 NEXTAUTH_SECRET_FILE="${NEXTAUTH_SECRET_FILE:-${APP_STATE_DIR}/nextauth_secret}"
@@ -134,9 +136,25 @@ else
   htpasswd -Bb "${RADICALE_USERS_FILE}" "${RADICALE_USERNAME}" "${RADICALE_PASSWORD}"
 fi
 
+if id "${RADICALE_RUN_USER}" >/dev/null 2>&1; then
+  if [ -d "${RADICALE_STORAGE%/}" ]; then
+    chown -R "${RADICALE_RUN_USER}:${RADICALE_RUN_GROUP}" "${RADICALE_STORAGE%/}"
+    chmod -R u+rwX,g+rwX,o-rwx "${RADICALE_STORAGE%/}"
+  fi
+  if [ -f "${RADICALE_USERS_FILE}" ]; then
+    chown "${RADICALE_RUN_USER}:${RADICALE_RUN_GROUP}" "${RADICALE_USERS_FILE}"
+    chmod 640 "${RADICALE_USERS_FILE}"
+  fi
+fi
+
 # Start Radicale in background
-radicale --config "${RADICALE_CONFIG}" &
-RADICALE_PID=$!
+if id "${RADICALE_RUN_USER}" >/dev/null 2>&1 && [ "$(id -un)" != "${RADICALE_RUN_USER}" ]; then
+  su -s /bin/sh "${RADICALE_RUN_USER}" -c "radicale --config '${RADICALE_CONFIG}'" &
+  RADICALE_PID=$!
+else
+  radicale --config "${RADICALE_CONFIG}" &
+  RADICALE_PID=$!
+fi
 
 # Wait for PostgreSQL to accept connections
 until pg_isready -h 127.0.0.1 -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; do

--- a/docker/pi/entrypoint.sh
+++ b/docker/pi/entrypoint.sh
@@ -17,11 +17,16 @@ RADICALE_BIN="${RADICALE_BIN:-/opt/radicale/bin/radicale}"
 RADICALE_LISTEN_HOST="${RADICALE_LISTEN_HOST:-127.0.0.1}"
 RADICALE_LISTEN_PORT="${RADICALE_LISTEN_PORT:-5232}"
 RADICALE_START_TIMEOUT="${RADICALE_START_TIMEOUT:-30}"
+RADICALE_LOG_FILE="${RADICALE_LOG_FILE:-${APP_STATE_DIR}/logs/radicale.log}"
 
 APP_STATE_DIR="${APP_STATE_DIR:-/var/lib/fluidcalendar}"
 NEXTAUTH_SECRET_FILE="${NEXTAUTH_SECRET_FILE:-${APP_STATE_DIR}/nextauth_secret}"
 
 mkdir -p "${APP_STATE_DIR}"
+mkdir -p "$(dirname "${RADICALE_LOG_FILE}")"
+
+: > "${RADICALE_LOG_FILE}"
+chmod 640 "${RADICALE_LOG_FILE}"
 
 if [ -z "${NEXTAUTH_SECRET:-}" ]; then
   if [ -s "${NEXTAUTH_SECRET_FILE}" ]; then
@@ -149,6 +154,8 @@ if id "${RADICALE_RUN_USER}" >/dev/null 2>&1; then
     chown "${RADICALE_RUN_USER}:${RADICALE_RUN_GROUP}" "${RADICALE_USERS_FILE}"
     chmod 640 "${RADICALE_USERS_FILE}"
   fi
+  chown "${RADICALE_RUN_USER}:${RADICALE_RUN_GROUP}" "${RADICALE_LOG_FILE}"
+  chmod 640 "${RADICALE_LOG_FILE}"
 fi
 
 start_radicale() {
@@ -159,26 +166,65 @@ start_radicale() {
     return 1
   fi
 
+  RADICALE_PID=
+  local radicale_launch_success=0
+
   if id "${RADICALE_RUN_USER}" >/dev/null 2>&1 && [ "$(id -un)" != "${RADICALE_RUN_USER}" ]; then
     if command -v runuser >/dev/null 2>&1; then
-      runuser -u "${RADICALE_RUN_USER}" -- "${radicale_cmd[@]}" &
-    else
-      su -s /bin/sh "${RADICALE_RUN_USER}" -c "$(printf '%q ' "${radicale_cmd[@]}")" &
+      set +e
+      runuser -u "${RADICALE_RUN_USER}" -- "${radicale_cmd[@]}" >>"${RADICALE_LOG_FILE}" 2>&1 &
+      RADICALE_PID=$!
+      radicale_launch_success=$?
+      set -e
+    fi
+
+    if [ ${radicale_launch_success} -ne 0 ] || [ -z "${RADICALE_PID:-}" ]; then
+      echo "runuser failed to start Radicale, falling back to su." >&2
+      set +e
+      su -s /bin/sh "${RADICALE_RUN_USER}" -c "exec $(printf '%q ' "${radicale_cmd[@]}")" >>"${RADICALE_LOG_FILE}" 2>&1 &
+      RADICALE_PID=$!
+      radicale_launch_success=$?
+      set -e
     fi
   else
-    "${radicale_cmd[@]}" &
+    "${radicale_cmd[@]}" >>"${RADICALE_LOG_FILE}" 2>&1 &
+    RADICALE_PID=$!
   fi
 
-  RADICALE_PID=$!
+  if [ ${radicale_launch_success} -ne 0 ]; then
+    echo "Failed to start Radicale process. Last log lines:" >&2
+    tail -n 40 "${RADICALE_LOG_FILE}" >&2 || true
+    return 1
+  fi
+
+  if ! command -v nc >/dev/null 2>&1; then
+    echo "nc command not available; skipping Radicale port probe." >&2
+    sleep 2
+    if ! kill -0 "${RADICALE_PID}" >/dev/null 2>&1; then
+      echo "Radicale exited unexpectedly. Last log lines:" >&2
+      tail -n 40 "${RADICALE_LOG_FILE}" >&2 || true
+      return 1
+    fi
+    return 0
+  fi
+
+  local -a probe_hosts=()
+  if [ -n "${RADICALE_LISTEN_HOST}" ]; then
+    probe_hosts+=("${RADICALE_LISTEN_HOST}")
+  fi
+  probe_hosts+=("127.0.0.1" "::1")
 
   for _ in $(seq 1 "${RADICALE_START_TIMEOUT}"); do
-    if nc -z "${RADICALE_LISTEN_HOST}" "${RADICALE_LISTEN_PORT}" >/dev/null 2>&1; then
-      echo "Radicale is listening on ${RADICALE_LISTEN_HOST}:${RADICALE_LISTEN_PORT}."
-      return 0
-    fi
+    for host in "${probe_hosts[@]}"; do
+      if nc -z "${host}" "${RADICALE_LISTEN_PORT}" >/dev/null 2>&1; then
+        echo "Radicale is listening on ${host}:${RADICALE_LISTEN_PORT}."
+        return 0
+      fi
+    done
 
     if ! kill -0 "${RADICALE_PID}" >/dev/null 2>&1; then
-      echo "Radicale exited before opening ${RADICALE_LISTEN_HOST}:${RADICALE_LISTEN_PORT}." >&2
+      echo "Radicale exited before opening port ${RADICALE_LISTEN_PORT}. Last log lines:" >&2
+      tail -n 40 "${RADICALE_LOG_FILE}" >&2 || true
       wait "${RADICALE_PID}" || true
       return 1
     fi
@@ -186,7 +232,8 @@ start_radicale() {
     sleep 1
   done
 
-  echo "Timed out waiting for Radicale to start on ${RADICALE_LISTEN_HOST}:${RADICALE_LISTEN_PORT}." >&2
+  echo "Timed out waiting for Radicale to start on port ${RADICALE_LISTEN_PORT}. Last log lines:" >&2
+  tail -n 40 "${RADICALE_LOG_FILE}" >&2 || true
   return 1
 }
 

--- a/docker/pi/entrypoint.sh
+++ b/docker/pi/entrypoint.sh
@@ -13,6 +13,10 @@ RADICALE_USERS_FILE="${RADICALE_USERS_FILE:-/etc/radicale/users}"
 RADICALE_STORAGE="${RADICALE_STORAGE:-/var/lib/radicale/collections}"
 RADICALE_RUN_USER="${RADICALE_RUN_USER:-radicale}"
 RADICALE_RUN_GROUP="${RADICALE_RUN_GROUP:-${RADICALE_RUN_USER}}"
+RADICALE_BIN="${RADICALE_BIN:-/opt/radicale/bin/radicale}"
+RADICALE_LISTEN_HOST="${RADICALE_LISTEN_HOST:-127.0.0.1}"
+RADICALE_LISTEN_PORT="${RADICALE_LISTEN_PORT:-5232}"
+RADICALE_START_TIMEOUT="${RADICALE_START_TIMEOUT:-30}"
 
 APP_STATE_DIR="${APP_STATE_DIR:-/var/lib/fluidcalendar}"
 NEXTAUTH_SECRET_FILE="${NEXTAUTH_SECRET_FILE:-${APP_STATE_DIR}/nextauth_secret}"
@@ -147,13 +151,48 @@ if id "${RADICALE_RUN_USER}" >/dev/null 2>&1; then
   fi
 fi
 
-# Start Radicale in background
-if id "${RADICALE_RUN_USER}" >/dev/null 2>&1 && [ "$(id -un)" != "${RADICALE_RUN_USER}" ]; then
-  su -s /bin/sh "${RADICALE_RUN_USER}" -c "radicale --config '${RADICALE_CONFIG}'" &
+start_radicale() {
+  local -a radicale_cmd=("${RADICALE_BIN}" "--config" "${RADICALE_CONFIG}")
+
+  if [ ! -x "${RADICALE_BIN}" ]; then
+    echo "Radicale binary ${RADICALE_BIN} is not executable." >&2
+    return 1
+  fi
+
+  if id "${RADICALE_RUN_USER}" >/dev/null 2>&1 && [ "$(id -un)" != "${RADICALE_RUN_USER}" ]; then
+    if command -v runuser >/dev/null 2>&1; then
+      runuser -u "${RADICALE_RUN_USER}" -- "${radicale_cmd[@]}" &
+    else
+      su -s /bin/sh "${RADICALE_RUN_USER}" -c "$(printf '%q ' "${radicale_cmd[@]}")" &
+    fi
+  else
+    "${radicale_cmd[@]}" &
+  fi
+
   RADICALE_PID=$!
-else
-  radicale --config "${RADICALE_CONFIG}" &
-  RADICALE_PID=$!
+
+  for _ in $(seq 1 "${RADICALE_START_TIMEOUT}"); do
+    if nc -z "${RADICALE_LISTEN_HOST}" "${RADICALE_LISTEN_PORT}" >/dev/null 2>&1; then
+      echo "Radicale is listening on ${RADICALE_LISTEN_HOST}:${RADICALE_LISTEN_PORT}."
+      return 0
+    fi
+
+    if ! kill -0 "${RADICALE_PID}" >/dev/null 2>&1; then
+      echo "Radicale exited before opening ${RADICALE_LISTEN_HOST}:${RADICALE_LISTEN_PORT}." >&2
+      wait "${RADICALE_PID}" || true
+      return 1
+    fi
+
+    sleep 1
+  done
+
+  echo "Timed out waiting for Radicale to start on ${RADICALE_LISTEN_HOST}:${RADICALE_LISTEN_PORT}." >&2
+  return 1
+}
+
+if ! start_radicale; then
+  echo "Radicale failed to start. Exiting." >&2
+  exit 1
 fi
 
 # Wait for PostgreSQL to accept connections

--- a/docker/pi/radicale.config
+++ b/docker/pi/radicale.config
@@ -10,7 +10,7 @@ htpasswd_encryption = bcrypt
 type = owner_only
 
 [storage]
-type = filesystem
+type = multifilesystem
 filesystem_folder = /var/lib/radicale/collections
 
 [logging]

--- a/docker/pi/radicale.config
+++ b/docker/pi/radicale.config
@@ -10,7 +10,7 @@ htpasswd_encryption = bcrypt
 type = owner_only
 
 [storage]
-type = filesystem
+type = radicale.storage.filesystem
 filesystem_folder = /var/lib/radicale/collections
 
 [logging]

--- a/docker/pi/radicale.config
+++ b/docker/pi/radicale.config
@@ -10,7 +10,7 @@ htpasswd_encryption = bcrypt
 type = owner_only
 
 [storage]
-type = radicale.storage.filesystem
+type = filesystem
 filesystem_folder = /var/lib/radicale/collections
 
 [logging]

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -143,6 +143,7 @@ user on first start. The following environment variables control the defaults:
 | `RADICALE_LISTEN_HOST` | Hostname the health check probes while starting Radicale | `127.0.0.1` |
 | `RADICALE_LISTEN_PORT` | Port the entrypoint waits on before continuing startup | `5232` |
 | `RADICALE_START_TIMEOUT` | Seconds to wait for Radicale to open the listening port | `30` |
+| `RADICALE_LOG_FILE` | Path where Radicale stdout/stderr is persisted | `${APP_STATE_DIR}/logs/radicale.log` |
 | `DATABASE_URL` | Prisma connection string (auto-generated if omitted) | `postgresql://fluid:fluid@127.0.0.1:5432/fluid_calendar?schema=public` |
 | `NEXTAUTH_URL` | Public URL for OAuth callbacks and NextAuth | `http://192.168.1.132:3000` |
 | `NEXT_PUBLIC_APP_URL` | Public URL exposed to the browser | `http://192.168.1.132:3000` |
@@ -160,18 +161,21 @@ account:
 
 The Radicale instance stores calendars under `/var/lib/radicale/collections`.
 Mount this directory to persist calendar data between container restarts. The
-Radicale configuration now references the fully qualified
+Radicale configuration uses the fully qualified
 `radicale.storage.filesystem` backend so the bundled Python environment always
 finds the storage plugin, even when entry-point discovery is restricted on the
 Pi. During startup the entrypoint now launches Radicale via
-`/opt/radicale/bin/radicale`, waits for the service to open
+`/opt/radicale/bin/radicale`, records all stdout/stderr in
+`${APP_STATE_DIR}/logs/radicale.log`, waits for the service to open
 `${RADICALE_LISTEN_HOST}:${RADICALE_LISTEN_PORT}`, and bails out early if the
-process exits unexpectedly. The health check output appears in the container
-logs so you can immediately spot configuration or permission problems before
-the Node.js server starts. The entrypoint also continues to repair the owner
-and permissions of the Radicale storage and credentials file to match
-`RADICALE_RUN_USER`, preventing "permission denied" errors when switching
-between versions or after restoring backups.
+process exits unexpectedly. If the bundled `runuser` utility is unavailable the
+entrypoint automatically falls back to `su` so Radicale still runs under the
+dedicated `radicale` account. Whenever the readiness probe times out, the last
+log lines are printed to the container logs to make troubleshooting obvious
+before the Node.js server starts. The entrypoint also continues to repair the
+owner and permissions of the Radicale storage, credentials file, and log file
+to match `RADICALE_RUN_USER`, preventing "permission denied" errors when
+switching between versions or after restoring backups.
 
 ## Stopping the container
 

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -139,6 +139,10 @@ user on first start. The following environment variables control the defaults:
 | `RADICALE_BASE_URL` | Internal CalDAV base URL used by the app | `http://localhost:5232` |
 | `RADICALE_RUN_USER` | Unix user the Radicale service runs as (also owns `/var/lib/radicale`) | `radicale` |
 | `RADICALE_RUN_GROUP` | Group paired with `RADICALE_RUN_USER` | `radicale` |
+| `RADICALE_BIN` | Absolute path to the Radicale executable inside the container | `/opt/radicale/bin/radicale` |
+| `RADICALE_LISTEN_HOST` | Hostname the health check probes while starting Radicale | `127.0.0.1` |
+| `RADICALE_LISTEN_PORT` | Port the entrypoint waits on before continuing startup | `5232` |
+| `RADICALE_START_TIMEOUT` | Seconds to wait for Radicale to open the listening port | `30` |
 | `DATABASE_URL` | Prisma connection string (auto-generated if omitted) | `postgresql://fluid:fluid@127.0.0.1:5432/fluid_calendar?schema=public` |
 | `NEXTAUTH_URL` | Public URL for OAuth callbacks and NextAuth | `http://192.168.1.132:3000` |
 | `NEXT_PUBLIC_APP_URL` | Public URL exposed to the browser | `http://192.168.1.132:3000` |
@@ -159,10 +163,15 @@ Mount this directory to persist calendar data between container restarts. The
 Radicale configuration now references the fully qualified
 `radicale.storage.filesystem` backend so the bundled Python environment always
 finds the storage plugin, even when entry-point discovery is restricted on the
-Pi. On startup the entrypoint automatically adjusts the owner and permissions
-of the Radicale storage and credentials file to match `RADICALE_RUN_USER`,
-preventing "permission denied" errors when switching between versions or after
-restoring backups.
+Pi. During startup the entrypoint now launches Radicale via
+`/opt/radicale/bin/radicale`, waits for the service to open
+`${RADICALE_LISTEN_HOST}:${RADICALE_LISTEN_PORT}`, and bails out early if the
+process exits unexpectedly. The health check output appears in the container
+logs so you can immediately spot configuration or permission problems before
+the Node.js server starts. The entrypoint also continues to repair the owner
+and permissions of the Radicale storage and credentials file to match
+`RADICALE_RUN_USER`, preventing "permission denied" errors when switching
+between versions or after restoring backups.
 
 ## Stopping the container
 

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -172,13 +172,48 @@ PostgreSQL.
 
 ## Update to a newer version later on
 
-When new commits land upstream, pull the updates and rebuild:
+When new commits land upstream, you can either use Git and Docker Compose
+directly:
 
 ```bash
 cd /path/to/fluid-calendar
 git pull
 docker compose -f docker-compose.pi.yml --env-file .env.pi up -d --build
 ```
+
+or leverage the helper functions in `scripts/pi-version-manager.sh` to switch
+between tagged releases without remembering the exact commands.
+
+### Optional: Version switching helpers
+
+To make it easy to jump between versions on the Raspberry Pi, source the helper
+functions once per shell session:
+
+```bash
+cd /path/to/fluid-calendar
+source scripts/pi-version-manager.sh
+```
+
+You can also add the `source` command to your shell profile (e.g. `~/.bashrc`)
+to load the helpers automatically when you SSH into the Pi.
+
+Available commands:
+
+| Command | Description |
+| --- | --- |
+| `fc_pi_list_versions` | Show all available Git tags in ascending order. |
+| `fc_pi_current_version` | Print the currently checked-out branch or tag. |
+| `fc_pi_use_version <ref>` | Checkout the given branch/tag, remove orphaned containers, and rebuild/start the Pi stack. |
+| `fc_pi_next_version` | Switch to the next tag (newer version) and rebuild. |
+| `fc_pi_previous_version` | Switch to the previous tag (older version) and rebuild. |
+| `fc_pi_rebuild_current` | Rebuild and restart the currently checked-out version. |
+| `fc_pi_status` | Show current repo/Compose status for the Pi stack. |
+
+All commands automatically run `docker compose down --remove-orphans` before
+starting the stack again so outdated containers are cleaned up. By default they
+expect `.env.pi` to exist, but you can override paths via the environment
+variables `FC_PI_REPO_DIR`, `FC_PI_COMPOSE_FILE`, `FC_PI_ENV_FILE`, and
+`FC_PI_DOCKER_COMPOSE` before sourcing the script.
 
 Docker Compose will recreate the container while keeping the PostgreSQL and
 Radicale volumes intact.

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -155,11 +155,14 @@ account:
 - **Username/Password:** values from `RADICALE_USERNAME` and `RADICALE_PASSWORD`
 
 The Radicale instance stores calendars under `/var/lib/radicale/collections`.
-Mount this directory to persist calendar data between container restarts. On
-startup the entrypoint automatically adjusts the owner and permissions of the
-Radicale storage and credentials file to match `RADICALE_RUN_USER`, preventing
-"permission denied" errors when switching between versions or after restoring
-backups.
+Mount this directory to persist calendar data between container restarts. The
+Radicale configuration now references the fully qualified
+`radicale.storage.filesystem` backend so the bundled Python environment always
+finds the storage plugin, even when entry-point discovery is restricted on the
+Pi. On startup the entrypoint automatically adjusts the owner and permissions
+of the Radicale storage and credentials file to match `RADICALE_RUN_USER`,
+preventing "permission denied" errors when switching between versions or after
+restoring backups.
 
 ## Stopping the container
 

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -140,6 +140,9 @@ user on first start. The following environment variables control the defaults:
 | `RADICALE_RUN_USER` | Unix user the Radicale service runs as (also owns `/var/lib/radicale`) | `radicale` |
 | `RADICALE_RUN_GROUP` | Group paired with `RADICALE_RUN_USER` | `radicale` |
 | `RADICALE_BIN` | Absolute path to the Radicale executable inside the container | `/opt/radicale/bin/radicale` |
+| `RADICALE_PYTHON_BIN` | Python interpreter used to inspect Radicale plugins | derived from `RADICALE_BIN` |
+| `RADICALE_STORAGE_TYPE` | Force a specific Radicale storage backend (`auto` enables detection) | `auto` |
+| `RADICALE_STORAGE_CANDIDATES` | Space-delimited list of backends probed when `RADICALE_STORAGE_TYPE=auto` | `"multifilesystem filesystem"` |
 | `RADICALE_LISTEN_HOST` | Hostname the health check probes while starting Radicale | `127.0.0.1` |
 | `RADICALE_LISTEN_PORT` | Port the entrypoint waits on before continuing startup | `5232` |
 | `RADICALE_START_TIMEOUT` | Seconds to wait for Radicale to open the listening port | `30` |
@@ -160,22 +163,26 @@ account:
 - **Username/Password:** values from `RADICALE_USERNAME` and `RADICALE_PASSWORD`
 
 The Radicale instance stores calendars under `/var/lib/radicale/collections`.
-Mount this directory to persist calendar data between container restarts. The
-Radicale configuration explicitly selects the builtin `filesystem` backend so
-the bundled Python environment always loads the correct storage plugin even
-when entry-point discovery is restricted on the Pi. During startup the
-entrypoint now launches Radicale via
-`/opt/radicale/bin/radicale`, records all stdout/stderr in
-`${APP_STATE_DIR}/logs/radicale.log`, waits for the service to open
-`${RADICALE_LISTEN_HOST}:${RADICALE_LISTEN_PORT}`, and bails out early if the
-process exits unexpectedly. If the bundled `runuser` utility is unavailable the
-entrypoint automatically falls back to `su` so Radicale still runs under the
-dedicated `radicale` account. Whenever the readiness probe times out, the last
-log lines are printed to the container logs to make troubleshooting obvious
-before the Node.js server starts. The entrypoint also continues to repair the
-owner and permissions of the Radicale storage, credentials file, and log file
-to match `RADICALE_RUN_USER`, preventing "permission denied" errors when
-switching between versions or after restoring backups.
+Mount this directory to persist calendar data between container restarts. On
+startup the entrypoint now inspects the Radicale installation with the
+configured Python interpreter and picks the first available backend from the
+`RADICALE_STORAGE_CANDIDATES` list (by default `multifilesystem`, falling back
+to `filesystem`). Setting `RADICALE_STORAGE_TYPE` to a specific value bypasses
+autodetection entirely. Once the backend is determined the entrypoint rewrites
+`/etc/radicale/config` accordingly so Radicale starts with a compatible storage
+module even if certain plugins are missing on older Pi images. The entrypoint
+then launches Radicale via `/opt/radicale/bin/radicale`, records
+all stdout/stderr in `${APP_STATE_DIR}/logs/radicale.log`, waits for the
+service to open `${RADICALE_LISTEN_HOST}:${RADICALE_LISTEN_PORT}`, and bails out
+early if the process exits unexpectedly. If the bundled `runuser` utility is
+unavailable the entrypoint automatically falls back to `su` so Radicale still
+runs under the dedicated `radicale` account. Whenever the readiness probe times
+out, the last log lines are printed to the container logs to make
+troubleshooting obvious before the Node.js server starts. The entrypoint also
+continues to repair the owner and permissions of the Radicale storage,
+credentials file, and log file to match `RADICALE_RUN_USER`, preventing
+"permission denied" errors when switching between versions or after restoring
+backups.
 
 ## Stopping the container
 

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -137,6 +137,8 @@ user on first start. The following environment variables control the defaults:
 | `RADICALE_USERNAME` | Radicale Basic Auth username | `fluid` |
 | `RADICALE_PASSWORD` | Radicale Basic Auth password | `fluid` |
 | `RADICALE_BASE_URL` | Internal CalDAV base URL used by the app | `http://localhost:5232` |
+| `RADICALE_RUN_USER` | Unix user the Radicale service runs as (also owns `/var/lib/radicale`) | `radicale` |
+| `RADICALE_RUN_GROUP` | Group paired with `RADICALE_RUN_USER` | `radicale` |
 | `DATABASE_URL` | Prisma connection string (auto-generated if omitted) | `postgresql://fluid:fluid@127.0.0.1:5432/fluid_calendar?schema=public` |
 | `NEXTAUTH_URL` | Public URL for OAuth callbacks and NextAuth | `http://192.168.1.132:3000` |
 | `NEXT_PUBLIC_APP_URL` | Public URL exposed to the browser | `http://192.168.1.132:3000` |
@@ -153,7 +155,11 @@ account:
 - **Username/Password:** values from `RADICALE_USERNAME` and `RADICALE_PASSWORD`
 
 The Radicale instance stores calendars under `/var/lib/radicale/collections`.
-Mount this directory to persist calendar data between container restarts.
+Mount this directory to persist calendar data between container restarts. On
+startup the entrypoint automatically adjusts the owner and permissions of the
+Radicale storage and credentials file to match `RADICALE_RUN_USER`, preventing
+"permission denied" errors when switching between versions or after restoring
+backups.
 
 ## Stopping the container
 

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -161,10 +161,10 @@ account:
 
 The Radicale instance stores calendars under `/var/lib/radicale/collections`.
 Mount this directory to persist calendar data between container restarts. The
-Radicale configuration uses the fully qualified
-`radicale.storage.filesystem` backend so the bundled Python environment always
-finds the storage plugin, even when entry-point discovery is restricted on the
-Pi. During startup the entrypoint now launches Radicale via
+Radicale configuration explicitly selects the builtin `filesystem` backend so
+the bundled Python environment always loads the correct storage plugin even
+when entry-point discovery is restricted on the Pi. During startup the
+entrypoint now launches Radicale via
 `/opt/radicale/bin/radicale`, records all stdout/stderr in
 `${APP_STATE_DIR}/logs/radicale.log`, waits for the service to open
 `${RADICALE_LISTEN_HOST}:${RADICALE_LISTEN_PORT}`, and bails out early if the

--- a/scripts/pi-version-manager.sh
+++ b/scripts/pi-version-manager.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Utility functions to simplify managing FluidCalendar versions on a Raspberry Pi.
+#
+# Source this file on the Pi (e.g. `source scripts/pi-version-manager.sh`) to
+# gain helper functions for switching between tagged releases, rebuilding the
+# container, and cleaning up Compose state. The functions assume the repository
+# has been cloned onto the device and Docker Compose is available as `docker compose`.
+
+set -euo pipefail
+
+# Allow overriding defaults through environment variables before sourcing.
+FC_PI_REPO_DIR=${FC_PI_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}
+FC_PI_COMPOSE_FILE=${FC_PI_COMPOSE_FILE:-docker-compose.pi.yml}
+FC_PI_ENV_FILE=${FC_PI_ENV_FILE:-.env.pi}
+FC_PI_DOCKER_COMPOSE=${FC_PI_DOCKER_COMPOSE:-docker compose}
+
+_fc_pi_repo() {
+  git -C "$FC_PI_REPO_DIR" "$@"
+}
+
+_fc_pi_check_clean() {
+  if [[ -n "$(_fc_pi_repo status --porcelain)" ]]; then
+    echo "Working tree has uncommitted changes. Commit or stash them before switching versions." >&2
+    return 1
+  fi
+}
+
+_fc_pi_ensure_env() {
+  if [[ ! -f "$FC_PI_REPO_DIR/$FC_PI_ENV_FILE" ]]; then
+    echo "Environment file '$FC_PI_ENV_FILE' not found in $FC_PI_REPO_DIR. Create it (e.g. cp docs/examples/pi.env.example $FC_PI_ENV_FILE)." >&2
+    return 1
+  fi
+}
+
+_fc_pi_compose() {
+  $FC_PI_DOCKER_COMPOSE -f "$FC_PI_REPO_DIR/$FC_PI_COMPOSE_FILE" --env-file "$FC_PI_REPO_DIR/$FC_PI_ENV_FILE" "$@"
+}
+
+_fc_pi_tag_list() {
+  _fc_pi_repo tag --sort=version:refname
+}
+
+_fc_pi_current_ref() {
+  if _fc_pi_repo describe --tags --exact-match >/dev/null 2>&1; then
+    _fc_pi_repo describe --tags --exact-match
+  else
+    _fc_pi_repo rev-parse --abbrev-ref HEAD
+  fi
+}
+
+_fc_pi_tags_array() {
+  mapfile -t FC_PI_TAGS < <(_fc_pi_tag_list)
+}
+
+fc_pi_list_versions() {
+  echo "Available tags (ascending):"
+  _fc_pi_tag_list
+}
+
+fc_pi_current_version() {
+  _fc_pi_current_ref
+}
+
+fc_pi_use_version() {
+  if [[ $# -ne 1 ]]; then
+    echo "Usage: fc_pi_use_version <git-ref>" >&2
+    return 1
+  fi
+
+  local ref=$1
+
+  _fc_pi_check_clean || return 1
+  _fc_pi_ensure_env || return 1
+
+  echo "Fetching updates..."
+  _fc_pi_repo fetch --tags
+
+  echo "Checking out $ref ..."
+  _fc_pi_repo checkout "$ref"
+
+  echo "Stopping existing containers (removing orphans)..."
+  _fc_pi_compose down --remove-orphans
+
+  echo "Building and starting $ref ..."
+  _fc_pi_compose up -d --build
+
+  echo "Switched to $(fc_pi_current_version)"
+}
+
+fc_pi_next_version() {
+  _fc_pi_check_clean || return 1
+  _fc_pi_tags_array
+
+  local current=$(_fc_pi_current_ref)
+  local idx=-1
+
+  for i in "${!FC_PI_TAGS[@]}"; do
+    if [[ "${FC_PI_TAGS[$i]}" == "$current" ]]; then
+      idx=$i
+      break
+    fi
+  done
+
+  if (( idx < 0 )); then
+    echo "Current ref '$current' is not a tagged release. Use fc_pi_use_version <tag> first." >&2
+    return 1
+  fi
+
+  if (( idx + 1 >= ${#FC_PI_TAGS[@]} )); then
+    echo "Already at the newest tag (or no newer tag available)." >&2
+    return 1
+  fi
+
+  fc_pi_use_version "${FC_PI_TAGS[$((idx + 1))]}"
+}
+
+fc_pi_previous_version() {
+  _fc_pi_check_clean || return 1
+  _fc_pi_tags_array
+
+  local current=$(_fc_pi_current_ref)
+  local idx=-1
+
+  for i in "${!FC_PI_TAGS[@]}"; do
+    if [[ "${FC_PI_TAGS[$i]}" == "$current" ]]; then
+      idx=$i
+      break
+    fi
+  done
+
+  if (( idx < 0 )); then
+    echo "Current ref '$current' is not a tagged release. Use fc_pi_use_version <tag> first." >&2
+    return 1
+  fi
+
+  if (( idx == 0 )); then
+    echo "Already at the earliest tag (or no previous tag available)." >&2
+    return 1
+  fi
+
+  fc_pi_use_version "${FC_PI_TAGS[$((idx - 1))]}"
+}
+
+fc_pi_rebuild_current() {
+  _fc_pi_check_clean || return 1
+  _fc_pi_ensure_env || return 1
+
+  local current=$(_fc_pi_current_ref)
+  echo "Rebuilding current ref $current ..."
+  _fc_pi_compose down --remove-orphans
+  _fc_pi_compose up -d --build
+}
+
+fc_pi_status() {
+  echo "Repository: $FC_PI_REPO_DIR"
+  echo "Compose file: $FC_PI_COMPOSE_FILE"
+  echo "Env file: $FC_PI_ENV_FILE"
+  echo "Current ref: $(_fc_pi_current_ref)"
+  echo "Containers:"
+  _fc_pi_compose ps
+}
+

--- a/src/app/(common)/calendar/page.tsx
+++ b/src/app/(common)/calendar/page.tsx
@@ -54,7 +54,7 @@ export default async function HomePage() {
       id: feed.id,
       name: feed.name,
       url: feed.url || undefined,
-      type: feed.type as "GOOGLE" | "OUTLOOK" | "CALDAV",
+      type: feed.type as "GOOGLE" | "OUTLOOK" | "CALDAV" | "LOCAL",
       color: feed.color || undefined,
       enabled: feed.enabled,
       createdAt: feed.createdAt,

--- a/src/app/(common)/settings/page.tsx
+++ b/src/app/(common)/settings/page.tsx
@@ -9,6 +9,7 @@ import { AccountManager } from "@/components/settings/AccountManager";
 import { AutoScheduleSettings } from "@/components/settings/AutoScheduleSettings";
 import { CalendarSettings } from "@/components/settings/CalendarSettings";
 import { ImportExportSettings } from "@/components/settings/ImportExportSettings";
+import { IcalImportSettings } from "@/components/settings/IcalImportSettings";
 import { LogViewer } from "@/components/settings/LogViewer";
 import { NotificationSettings } from "@/components/settings/NotificationSettings";
 import { SystemSettings } from "@/components/settings/SystemSettings";
@@ -51,6 +52,7 @@ type SettingsTab =
   | "user-management"
   | "waitlist"
   | "import-export"
+  | "ical-import"
   | "admin-dashboard"
   | "notifications";
 
@@ -73,6 +75,7 @@ export default function SettingsPage() {
       { id: "task-sync", label: "Task Sync" },
       { id: "notifications", label: "Notifications" },
       { id: "import-export", label: "Import/Export" },
+      { id: "ical-import", label: "iCal Import" },
     ] as const;
 
     // Add admin-only tabs
@@ -118,6 +121,7 @@ export default function SettingsPage() {
         "user-management",
         "waitlist",
         "import-export",
+        "ical-import",
         "admin-dashboard",
         "notifications",
       ];
@@ -199,6 +203,8 @@ export default function SettingsPage() {
         return <UserManagement />;
       case "import-export":
         return <ImportExportSettings />;
+      case "ical-import":
+        return <IcalImportSettings />;
       case "waitlist":
         return (
           <Suspense fallback={<div>Loading...</div>}>

--- a/src/app/api/import/ical/route.ts
+++ b/src/app/api/import/ical/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import ICAL from "ical.js";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
+
+import type { Prisma } from "@prisma/client";
 
 import { authenticateRequest } from "@/lib/auth/api-auth";
 import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
+import { CalDAVCalendarService } from "@/lib/caldav-calendar";
 
 const LOG_SOURCE = "import-ical-api";
 
@@ -63,6 +66,40 @@ interface ParsedCalendar {
   calendarName?: string;
   calendarColor?: string;
   skipped: number;
+}
+
+interface NormalizedParsedEvent extends ParsedEvent {
+  storageUid: string;
+  storageBaseUid: string;
+  storageMasterUid?: string;
+}
+
+type CalendarFeedWithAccount = Prisma.CalendarFeedGetPayload<{
+  include: { account: true };
+}>;
+
+function makeSafeIdentifier(raw: string | undefined): string {
+  if (!raw) {
+    return `ical-${randomUUID()}`;
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return `ical-${randomUUID()}`;
+  }
+
+  const candidate = trimmed
+    .replace(/[^a-zA-Z0-9._~-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-._~]+|[-._~]+$/g, "")
+    .slice(0, 180);
+
+  if (candidate && !candidate.includes("/")) {
+    return candidate;
+  }
+
+  const hashed = createHash("sha256").update(trimmed).digest("base64url");
+  return `ical-${hashed}`;
 }
 
 function sanitizeText(value: unknown): string | undefined {
@@ -456,9 +493,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    let targetFeed = null as Awaited<
-      ReturnType<typeof prisma.calendarFeed.findFirst>
-    >;
+    let targetFeed: CalendarFeedWithAccount | null = null;
 
     if (payload.feedId) {
       targetFeed = await prisma.calendarFeed.findFirst({
@@ -472,6 +507,9 @@ export async function POST(request: NextRequest) {
               },
             },
           ],
+        },
+        include: {
+          account: true,
         },
       });
 
@@ -596,122 +634,232 @@ export async function POST(request: NextRequest) {
       return a.start.getTime() - b.start.getTime();
     });
 
+    const normalizedEvents: NormalizedParsedEvent[] = orderedEvents.map(
+      (event) => {
+        const storageBaseUid = makeSafeIdentifier(event.baseUid);
+        const storageUid = event.isMaster
+          ? storageBaseUid
+          : makeSafeIdentifier(
+              event.externalEventId ??
+                `${event.baseUid}-${event.start.toISOString()}`
+            );
+        const storageMasterUid = event.isMaster
+          ? undefined
+          : makeSafeIdentifier(event.masterUid ?? event.baseUid);
+
+        return {
+          ...event,
+          storageUid,
+          storageBaseUid,
+          storageMasterUid,
+        };
+      }
+    );
+
     const externalIdsToReplace = Array.from(
       new Set(
-        orderedEvents
-          .map((event) => event.externalEventId?.trim())
-          .filter((id): id is string => typeof id === "string" && id.length > 0)
+        normalizedEvents.flatMap((event) => {
+          const identifiers = [event.storageUid];
+          const legacyId = event.externalEventId?.trim();
+          if (legacyId && legacyId !== event.storageUid) {
+            identifiers.push(legacyId);
+          }
+          return identifiers;
+        })
       )
     );
 
-    const { feed, imported, skipped } = await prisma.$transaction(
-      async (tx) => {
-        const resolvedFeed =
-          targetFeed ??
-          (await tx.calendarFeed.create({
-            data: {
-              name: feedName,
-              color: desiredColor ?? "#3b82f6",
-              type: "LOCAL",
-              enabled: true,
-              userId: auth.userId,
-            },
-          }));
+    let feed: CalendarFeedWithAccount;
 
-        if (externalIdsToReplace.length) {
-          await tx.calendarEvent.deleteMany({
-            where: {
-              feedId: resolvedFeed.id,
-              externalEventId: { in: externalIdsToReplace },
-            },
-          });
-        }
+    if (targetFeed) {
+      feed = targetFeed;
+    } else {
+      const createdFeed = await prisma.calendarFeed.create({
+        data: {
+          name: feedName,
+          color: desiredColor ?? "#3b82f6",
+          type: "LOCAL",
+          enabled: true,
+          userId: auth.userId,
+        },
+      });
 
-        const masterMap = new Map<string, string>();
-        let importedCount = 0;
-        let storageFailures = 0;
+      feed = {
+        ...createdFeed,
+        account: null,
+      } as CalendarFeedWithAccount;
+    }
 
-        for (const event of orderedEvents) {
-          try {
-            const masterEventId = event.masterUid
-              ? masterMap.get(event.masterUid) || null
-              : null;
+    let caldavContext: {
+      service: CalDAVCalendarService;
+      calendarPath: string;
+    } | null = null;
 
-            const createdEvent = await tx.calendarEvent.create({
-              data: {
-                feedId: resolvedFeed.id,
-                externalEventId: event.externalEventId,
-                title: event.title,
-                description: event.description,
-                start: event.start,
-                end: event.end,
-                location: event.location,
-                isRecurring: event.isRecurring,
-                recurrenceRule: event.recurrenceRule,
-                allDay: event.allDay,
-                status: event.status,
-                sequence: event.sequence,
-                created: event.created,
-                lastModified: event.lastModified,
-                isMaster: event.isMaster,
-                masterEventId,
-                recurringEventId: event.isRecurring
-                  ? event.isMaster
-                    ? event.baseUid
-                    : event.masterUid || event.baseUid
-                  : null,
-                organizer: event.organizer
-                  ? {
-                      name: event.organizer.name,
-                      email: event.organizer.email,
-                    }
-                  : undefined,
-                attendees: event.attendees?.length
-                  ? event.attendees.map((attendee) => ({
-                      name: attendee.name,
-                      email: attendee.email,
-                      status: attendee.status,
-                    }))
-                  : undefined,
-              },
-            });
-
-            if (event.isMaster) {
-              masterMap.set(event.baseUid, createdEvent.id);
-            }
-
-            importedCount += 1;
-          } catch (error) {
-            storageFailures += 1;
-            logger.error(
-              "Fehler beim Speichern eines Termins",
-              {
-                feedId: resolvedFeed.id,
-                externalEventId: event.externalEventId,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              LOG_SOURCE
-            );
-          }
-        }
-
-        return {
-          feed: resolvedFeed,
-          imported: importedCount,
-          skipped: parsed.skipped + storageFailures,
-        };
-      },
-      {
-        maxWait: 10_000,
-        timeout: 120_000,
+    if (feed.type === "CALDAV") {
+      const calendarPath = feed.url ?? feed.caldavPath;
+      if (!calendarPath) {
+        return NextResponse.json(
+          { error: "Für diesen CalDAV-Kalender ist kein Pfad hinterlegt" },
+          { status: 400 }
+        );
       }
-    );
+
+      const account =
+        targetFeed?.id === feed.id && targetFeed.account
+          ? targetFeed.account
+          : feed.accountId
+          ? await prisma.connectedAccount.findUnique({
+              where: { id: feed.accountId, userId: auth.userId },
+            })
+          : null;
+
+      if (!account) {
+        return NextResponse.json(
+          {
+            error:
+              "Es konnten keine Anmeldedaten für den CalDAV-Kalender geladen werden",
+          },
+          { status: 400 }
+        );
+      }
+
+      caldavContext = {
+        service: new CalDAVCalendarService(account),
+        calendarPath,
+      };
+    }
+
+    if (caldavContext) {
+      for (const event of normalizedEvents) {
+        try {
+          await caldavContext.service.putEvent(
+            caldavContext.calendarPath,
+            {
+              id: event.storageUid,
+              title: event.title,
+              description: event.description,
+              location: event.location,
+              start: event.start,
+              end: event.end,
+              allDay: event.allDay,
+              isRecurring: event.isRecurring,
+              recurrenceRule: event.recurrenceRule,
+            }
+          );
+        } catch (error) {
+          logger.error(
+            "Fehler beim Übertragen eines Termins an CalDAV",
+            {
+              feedId: feed.id,
+              externalEventId: event.storageUid,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            LOG_SOURCE
+          );
+
+          return NextResponse.json(
+            {
+              error:
+                "Die Termine konnten nicht im CalDAV-Kalender gespeichert werden",
+            },
+            { status: 502 }
+          );
+        }
+      }
+
+      await prisma.calendarFeed.update({
+        where: { id: feed.id },
+        data: {
+          lastSync: new Date(),
+          error: null,
+        },
+      });
+    }
+
+    if (externalIdsToReplace.length) {
+      await prisma.calendarEvent.deleteMany({
+        where: {
+          feedId: feed.id,
+          externalEventId: { in: externalIdsToReplace },
+        },
+      });
+    }
+
+    const masterMap = new Map<string, string>();
+    let importedCount = 0;
+    let storageFailures = 0;
+
+    for (const event of normalizedEvents) {
+      try {
+        const masterLookupKey =
+          event.storageMasterUid ?? event.storageBaseUid;
+        const masterEventId = event.isMaster
+          ? null
+          : masterMap.get(masterLookupKey) ?? null;
+
+        const createdEvent = await prisma.calendarEvent.create({
+          data: {
+            feedId: feed.id,
+            externalEventId: event.storageUid,
+            title: event.title,
+            description: event.description,
+            start: event.start,
+            end: event.end,
+            location: event.location,
+            isRecurring: event.isRecurring,
+            recurrenceRule: event.recurrenceRule,
+            allDay: event.allDay,
+            status: event.status,
+            sequence: event.sequence,
+            created: event.created,
+            lastModified: event.lastModified,
+            isMaster: event.isMaster,
+            masterEventId,
+            recurringEventId: event.isRecurring
+              ? event.storageBaseUid
+              : null,
+            organizer: event.organizer
+              ? {
+                  name: event.organizer.name,
+                  email: event.organizer.email,
+                }
+              : undefined,
+            attendees: event.attendees?.length
+              ? event.attendees.map((attendee) => ({
+                  name: attendee.name,
+                  email: attendee.email,
+                  status: attendee.status,
+                }))
+              : undefined,
+          },
+        });
+
+        if (event.isMaster) {
+          masterMap.set(event.storageBaseUid, createdEvent.id);
+        }
+
+        importedCount += 1;
+      } catch (error) {
+        storageFailures += 1;
+        logger.error(
+          "Fehler beim Speichern eines Termins",
+          {
+            feedId: feed.id,
+            externalEventId: event.storageUid,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          LOG_SOURCE
+        );
+      }
+    }
+
+    const skipped = parsed.skipped + storageFailures;
 
     logger.info(
       "iCal-Import abgeschlossen",
       {
         feedId: feed.id,
-        imported,
+        imported: importedCount,
         skipped,
       },
       LOG_SOURCE
@@ -719,7 +867,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       feedId: feed.id,
-      imported,
+      imported: importedCount,
       feedName: feed.name,
       skipped,
     });

--- a/src/app/api/import/ical/route.ts
+++ b/src/app/api/import/ical/route.ts
@@ -19,6 +19,24 @@ interface ImportPayload {
   icalUrl?: string;
 }
 
+type IcalProperty = {
+  name?: string;
+  getFirstValue?: () => unknown;
+  getValues?: () => unknown[];
+  getParameter?: (name: string) => unknown;
+};
+
+interface ParsedAttendee {
+  name?: string;
+  email: string;
+  status?: string;
+}
+
+interface ParsedOrganizer {
+  name?: string;
+  email: string;
+}
+
 interface ParsedEvent {
   baseUid: string;
   externalEventId: string;
@@ -36,12 +54,103 @@ interface ParsedEvent {
   isMaster: boolean;
   isRecurring: boolean;
   masterUid?: string;
+  organizer?: ParsedOrganizer;
+  attendees?: ParsedAttendee[];
 }
 
 interface ParsedCalendar {
   events: ParsedEvent[];
   calendarName?: string;
   calendarColor?: string;
+  skipped: number;
+}
+
+function sanitizeText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const normalized = value
+      .replace(/\\n/gi, "\n")
+      .replace(/\\,/g, ",")
+      .replace(/\\;/g, ";")
+      .replace(/\\\\/g, "\\")
+      .trim();
+    return normalized.length ? normalized : undefined;
+  }
+
+  if (value && typeof value === "object" && "toString" in value) {
+    return sanitizeText(String(value));
+  }
+
+  return undefined;
+}
+
+function sanitizeColor(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (/^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return null;
+}
+
+function normalizeEmail(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const email = value.replace(/^mailto:/i, "").trim();
+  if (!email) return undefined;
+  return email.toLowerCase();
+}
+
+function parseCalAddress(property: IcalProperty | null | undefined):
+  | ParsedOrganizer
+  | ParsedAttendee
+  | undefined {
+  if (!property) return undefined;
+
+  const rawValue = property.getFirstValue?.();
+  if (typeof rawValue !== "string") {
+    return undefined;
+  }
+
+  const email = normalizeEmail(rawValue);
+  if (!email) return undefined;
+
+  const commonNameParam = property.getParameter?.("cn");
+  const name =
+    typeof commonNameParam === "string"
+      ? sanitizeText(commonNameParam)
+      : undefined;
+
+  const attendeeStatusParam = property.getParameter?.("partstat");
+  const status =
+    typeof attendeeStatusParam === "string"
+      ? attendeeStatusParam.toUpperCase()
+      : undefined;
+
+  return {
+    email,
+    name,
+    status,
+  } as ParsedOrganizer | ParsedAttendee;
+}
+
+function mergeDescription(
+  baseDescription: string | undefined,
+  extraSections: Array<string | undefined>
+): string | undefined {
+  const sections = [baseDescription, ...extraSections];
+  const filtered = sections.filter(
+    (section): section is string =>
+      typeof section === "string" && section.trim().length > 0
+  );
+
+  if (!filtered.length) {
+    return undefined;
+  }
+
+  return filtered.map((section) => section.trim()).join("\n\n");
 }
 
 function parseIcalData(icalData: string): ParsedCalendar {
@@ -55,84 +164,222 @@ function parseIcalData(icalData: string): ParsedCalendar {
     }
 
     const calendarName = vcalendar.getFirstPropertyValue("x-wr-calname");
-    const calendarColor = vcalendar.getFirstPropertyValue("x-wr-calcolor");
+    const calendarColor = sanitizeColor(
+      vcalendar.getFirstPropertyValue("x-wr-calcolor")
+    );
 
-    const events: ParsedEvent[] = vevents.map((vevent) => {
-      const event = new ICAL.Event(vevent);
-      const baseUid = event.uid || randomUUID();
+    const events: ParsedEvent[] = [];
+    let skipped = 0;
 
-      if (!event.startDate) {
-        throw new Error(`Termin ohne Startzeit gefunden (${baseUid})`);
+    for (const vevent of vevents) {
+      try {
+        const event = new ICAL.Event(vevent);
+        const baseUid = event.uid || randomUUID();
+
+        if (!event.startDate) {
+          skipped += 1;
+          logger.warn(
+            "Termin ohne Startzeit übersprungen",
+            { uid: baseUid },
+            LOG_SOURCE
+          );
+          continue;
+        }
+
+        const rawStatus = vevent.getFirstPropertyValue("status");
+        const normalizedStatus =
+          typeof rawStatus === "string" ? rawStatus.toUpperCase() : undefined;
+        if (normalizedStatus === "CANCELLED") {
+          skipped += 1;
+          logger.debug(
+            "Stornierten Termin aus dem Import ausgelassen",
+            { uid: baseUid },
+            LOG_SOURCE
+          );
+          continue;
+        }
+
+        const start = event.startDate.toJSDate();
+        let end: Date;
+        if (event.endDate) {
+          end = event.endDate.toJSDate();
+        } else if (event.duration) {
+          const calculatedEnd = event.startDate.clone();
+          calculatedEnd.addDuration(event.duration);
+          end = calculatedEnd.toJSDate();
+        } else {
+          end = new Date(start.getTime() + 60 * 60 * 1000);
+        }
+
+        if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+          skipped += 1;
+          logger.warn(
+            "Termin mit ungültigem Datum übersprungen",
+            { uid: baseUid },
+            LOG_SOURCE
+          );
+          continue;
+        }
+
+        const recurrenceRuleValue = vevent.getFirstPropertyValue("rrule") as
+          | ICAL.Recur
+          | undefined;
+        const recurrenceRule = recurrenceRuleValue
+          ? recurrenceRuleValue.toString()
+          : undefined;
+
+        const hasRecurrenceId = vevent.hasProperty("recurrence-id");
+        const recurrenceIdValue = hasRecurrenceId
+          ? (vevent.getFirstPropertyValue("recurrence-id") as
+              | ICAL.Time
+              | undefined)
+          : undefined;
+        const recurrenceId = recurrenceIdValue
+          ? recurrenceIdValue.toString()
+          : undefined;
+
+        const createdValue = vevent.getFirstPropertyValue("created") as
+          | ICAL.Time
+          | undefined;
+        const lastModifiedValue = vevent.getFirstPropertyValue(
+          "last-modified"
+        ) as ICAL.Time | undefined;
+        const sequenceValue = vevent.getFirstPropertyValue("sequence");
+        const sequence =
+          typeof sequenceValue === "number" ? sequenceValue : undefined;
+
+        const description = sanitizeText(
+          vevent.getFirstPropertyValue("description")
+        );
+        const location = sanitizeText(
+          vevent.getFirstPropertyValue("location")
+        );
+        const url = sanitizeText(vevent.getFirstPropertyValue("url"));
+        const categorySet = new Set<string>();
+        const categoryProperties = vevent.getAllProperties(
+          "categories"
+        ) as IcalProperty[];
+        for (const property of categoryProperties) {
+          const values = property.getValues?.();
+          if (Array.isArray(values) && values.length) {
+            for (const value of values) {
+              const text = sanitizeText(value);
+              if (text) {
+                text
+                  .split(",")
+                  .map((entry) => entry.trim())
+                  .filter(Boolean)
+                  .forEach((entry) => categorySet.add(entry));
+              }
+            }
+            continue;
+          }
+
+          const single = sanitizeText(property.getFirstValue?.());
+          if (single) {
+            single
+              .split(",")
+              .map((entry) => entry.trim())
+              .filter(Boolean)
+              .forEach((entry) => categorySet.add(entry));
+          }
+        }
+        const categoryPropertyValues = Array.from(categorySet);
+
+        const customInfo = (vevent.getAllProperties() as IcalProperty[])
+          .filter((property) =>
+            typeof property.name === "string" && property.name.startsWith("X-")
+          )
+          .map((property) => {
+            const propName =
+              typeof property.name === "string" ? property.name : undefined;
+            const value = sanitizeText(property.getFirstValue?.());
+            if (!value || !propName) return undefined;
+
+            const label = propName
+              .replace(/^X-/i, "")
+              .replace(/[-_]/g, " ");
+            return `${label}: ${value}`;
+          })
+          .filter(Boolean) as string[];
+
+        const combinedDescription = mergeDescription(description, [
+          categoryPropertyValues.length
+            ? `Kategorien: ${categoryPropertyValues.join(", ")}`
+            : undefined,
+          url ? `Link: ${url}` : undefined,
+          customInfo.length ? customInfo.join("\n") : undefined,
+        ]);
+
+        const organizerProperty = vevent.getFirstProperty(
+          "organizer"
+        ) as IcalProperty | null;
+        const organizer = parseCalAddress(organizerProperty) as
+          | ParsedOrganizer
+          | undefined;
+
+        const attendeeMap = new Map<string, ParsedAttendee>();
+        const attendeeProperties = vevent.getAllProperties(
+          "attendee"
+        ) as IcalProperty[];
+        for (const property of attendeeProperties) {
+          const attendee = parseCalAddress(property) as ParsedAttendee | undefined;
+          if (attendee?.email) {
+            attendeeMap.set(attendee.email, attendee);
+          }
+        }
+        const attendees = attendeeMap.size
+          ? Array.from(attendeeMap.values())
+          : undefined;
+
+        events.push({
+          baseUid,
+          externalEventId:
+            hasRecurrenceId && recurrenceId
+              ? `${baseUid}-${recurrenceId}`
+              : baseUid,
+          title: sanitizeText(event.summary) || "Unbenannter Termin",
+          description: combinedDescription,
+          start,
+          end,
+          location,
+          allDay: event.startDate.isDate,
+          recurrenceRule,
+          status: normalizedStatus,
+          sequence,
+          created: createdValue ? createdValue.toJSDate() : undefined,
+          lastModified: lastModifiedValue
+            ? lastModifiedValue.toJSDate()
+            : undefined,
+          isMaster: !!recurrenceRule && !hasRecurrenceId,
+          isRecurring: !!recurrenceRule || hasRecurrenceId,
+          masterUid: hasRecurrenceId ? baseUid : undefined,
+          organizer,
+          attendees,
+        });
+      } catch (error) {
+        skipped += 1;
+        logger.error(
+          "Fehler beim Verarbeiten eines Termins aus dem iCal-Feed",
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+          LOG_SOURCE
+        );
       }
+    }
 
-      const start = event.startDate.toJSDate();
-      let end: Date;
-      if (event.endDate) {
-        end = event.endDate.toJSDate();
-      } else if (event.duration) {
-        const calculatedEnd = event.startDate.clone();
-        calculatedEnd.addDuration(event.duration);
-        end = calculatedEnd.toJSDate();
-      } else {
-        end = new Date(start.getTime() + 60 * 60 * 1000);
-      }
-
-      const recurrenceRuleValue = vevent.getFirstPropertyValue("rrule") as
-        | ICAL.Recur
-        | undefined;
-      const recurrenceRule = recurrenceRuleValue
-        ? recurrenceRuleValue.toString()
-        : undefined;
-
-      const hasRecurrenceId = vevent.hasProperty("recurrence-id");
-      const recurrenceIdValue = hasRecurrenceId
-        ? (vevent.getFirstPropertyValue("recurrence-id") as
-            | ICAL.Time
-            | undefined)
-        : undefined;
-      const recurrenceId = recurrenceIdValue
-        ? recurrenceIdValue.toString()
-        : undefined;
-
-      const createdValue = vevent.getFirstPropertyValue("created") as
-        | ICAL.Time
-        | undefined;
-      const lastModifiedValue = vevent.getFirstPropertyValue("last-modified") as
-        | ICAL.Time
-        | undefined;
-      const sequenceValue = vevent.getFirstPropertyValue("sequence");
-      const sequence =
-        typeof sequenceValue === "number" ? sequenceValue : undefined;
-
-      return {
-        baseUid,
-        externalEventId:
-          hasRecurrenceId && recurrenceId
-            ? `${baseUid}-${recurrenceId}`
-            : baseUid,
-        title: event.summary || "Unbenannter Termin",
-        description: event.description || undefined,
-        start,
-        end,
-        location: event.location || undefined,
-        allDay: event.startDate.isDate,
-        recurrenceRule,
-        status: (vevent.getFirstPropertyValue("status") as string | undefined) || undefined,
-        sequence,
-        created: createdValue ? createdValue.toJSDate() : undefined,
-        lastModified: lastModifiedValue
-          ? lastModifiedValue.toJSDate()
-          : undefined,
-        isMaster: !!recurrenceRule && !hasRecurrenceId,
-        isRecurring: !!recurrenceRule || hasRecurrenceId,
-        masterUid: hasRecurrenceId ? baseUid : undefined,
-      } satisfies ParsedEvent;
-    });
+    if (!events.length) {
+      throw new Error(
+        "Keine verarbeitbaren Termine in den iCal-Daten gefunden"
+      );
+    }
 
     return {
       events,
       calendarName: calendarName ? String(calendarName) : undefined,
-      calendarColor: calendarColor ? String(calendarColor) : undefined,
+      calendarColor: calendarColor || undefined,
+      skipped,
     };
   } catch (error) {
     logger.error(
@@ -201,9 +448,40 @@ export async function POST(request: NextRequest) {
 
     let icalData = payload.icalData;
 
+    let importUrl: URL | undefined;
+
     if (!icalData && payload.icalUrl) {
+      const trimmedUrl = payload.icalUrl.trim();
       try {
-        const response = await fetch(payload.icalUrl);
+        importUrl = new URL(trimmedUrl);
+      } catch (error) {
+        logger.error(
+          "Ungültige iCal-URL übermittelt",
+          {
+            url: payload.icalUrl ?? null,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          LOG_SOURCE
+        );
+        return NextResponse.json(
+          { error: "Die angegebene iCal-URL ist ungültig" },
+          { status: 400 }
+        );
+      }
+
+      if (!importUrl || !["http:", "https:"].includes(importUrl.protocol)) {
+        return NextResponse.json(
+          { error: "Nur HTTP- und HTTPS-Links werden unterstützt" },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (!icalData && importUrl) {
+      try {
+        const response = await fetch(importUrl.toString(), {
+          cache: "no-store",
+        });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
@@ -212,7 +490,7 @@ export async function POST(request: NextRequest) {
         logger.error(
           "Fehler beim Laden der iCal-URL",
           {
-            url: payload.icalUrl,
+            url: payload.icalUrl ?? importUrl.toString(),
             error: error instanceof Error ? error.message : String(error),
           },
           LOG_SOURCE
@@ -223,6 +501,15 @@ export async function POST(request: NextRequest) {
         );
       }
     }
+
+    if (!icalData) {
+      return NextResponse.json(
+        { error: "Die iCal-Daten sind leer" },
+        { status: 400 }
+      );
+    }
+
+    icalData = icalData.replace(/^\uFEFF/, "").trim();
 
     if (!icalData) {
       return NextResponse.json(
@@ -254,19 +541,16 @@ export async function POST(request: NextRequest) {
       payload.feedName?.trim() || parsedCalendarName || "Importierter Kalender";
 
     const desiredColor =
-      typeof payload.color === "string" && payload.color.trim().length > 0
-        ? payload.color.trim()
-        : parsed.calendarColor && String(parsed.calendarColor).trim().length > 0
-          ? String(parsed.calendarColor).trim()
-          : null;
+      sanitizeColor(payload.color) ?? parsed.calendarColor ?? null;
 
-    const { feed, imported } = await prisma.$transaction(async (tx) => {
+    const { feed, imported, skipped } = await prisma.$transaction(
+      async (tx) => {
       const resolvedFeed =
         targetFeed ??
         (await tx.calendarFeed.create({
           data: {
             name: feedName,
-            color: desiredColor,
+            color: desiredColor ?? "#3b82f6",
             type: "LOCAL",
             enabled: true,
             userId: auth.userId,
@@ -279,8 +563,10 @@ export async function POST(request: NextRequest) {
       const events = [...parsed.events].sort((a, b) => {
         if (a.isMaster && !b.isMaster) return -1;
         if (!a.isMaster && b.isMaster) return 1;
-        return 0;
+        return a.start.getTime() - b.start.getTime();
       });
+
+      let storageFailures = 0;
 
       for (const event of events) {
         try {
@@ -315,7 +601,24 @@ export async function POST(request: NextRequest) {
               lastModified: event.lastModified,
               isMaster: event.isMaster,
               masterEventId,
-              recurringEventId: event.masterUid || null,
+              recurringEventId: event.isRecurring
+                ? event.isMaster
+                  ? event.baseUid
+                  : event.masterUid || event.baseUid
+                : null,
+              organizer: event.organizer
+                ? {
+                    name: event.organizer.name,
+                    email: event.organizer.email,
+                  }
+                : undefined,
+              attendees: event.attendees?.length
+                ? event.attendees.map((attendee) => ({
+                    name: attendee.name,
+                    email: attendee.email,
+                    status: attendee.status,
+                  }))
+                : undefined,
             },
           });
 
@@ -325,6 +628,7 @@ export async function POST(request: NextRequest) {
 
           importedCount += 1;
         } catch (error) {
+          storageFailures += 1;
           logger.error(
             "Fehler beim Speichern eines Termins",
             {
@@ -337,14 +641,20 @@ export async function POST(request: NextRequest) {
         }
       }
 
-      return { feed: resolvedFeed, imported: importedCount };
-    });
+      return {
+        feed: resolvedFeed,
+        imported: importedCount,
+        skipped: parsed.skipped + storageFailures,
+      };
+    }
+    );
 
     logger.info(
       "iCal-Import abgeschlossen",
       {
         feedId: feed.id,
         imported,
+        skipped,
       },
       LOG_SOURCE
     );
@@ -353,6 +663,7 @@ export async function POST(request: NextRequest) {
       feedId: feed.id,
       imported,
       feedName: feed.name,
+      skipped,
     });
   } catch (error) {
     logger.error(

--- a/src/app/api/import/ical/route.ts
+++ b/src/app/api/import/ical/route.ts
@@ -153,9 +153,56 @@ function mergeDescription(
   return filtered.map((section) => section.trim()).join("\n\n");
 }
 
+function normalizeIcalContent(raw: string): string {
+  const unixNewlines = raw.replace(/\r\n?/g, "\n");
+  const lines = unixNewlines.split("\n");
+  const normalized: string[] = [];
+
+  for (const line of lines) {
+    if (!line.length) {
+      normalized.push(line);
+      continue;
+    }
+
+    if (/^[ \t]/.test(line)) {
+      if (normalized.length) {
+        normalized[normalized.length - 1] += line.slice(1);
+        continue;
+      }
+
+      normalized.push(line.trimStart());
+      continue;
+    }
+
+    if (!line.includes(":") && !line.includes(";")) {
+      if (normalized.length) {
+        const previous = normalized[normalized.length - 1];
+        const trimmed = line.trim();
+        const needsSpace =
+          trimmed.length > 0 &&
+          previous.length > 0 &&
+          !previous.endsWith(" ") &&
+          !previous.endsWith("\\") &&
+          !previous.endsWith("=");
+        normalized[normalized.length - 1] =
+          previous + (needsSpace ? " " : "") + trimmed;
+        continue;
+      }
+
+      normalized.push(line.trim());
+      continue;
+    }
+
+    normalized.push(line);
+  }
+
+  return normalized.join("\n");
+}
+
 function parseIcalData(icalData: string): ParsedCalendar {
   try {
-    const jcalData = ICAL.parse(icalData);
+    const normalized = normalizeIcalContent(icalData);
+    const jcalData = ICAL.parse(normalized);
     const vcalendar = new ICAL.Component(jcalData);
     const vevents = vcalendar.getAllSubcomponents("vevent");
 

--- a/src/app/api/import/ical/route.ts
+++ b/src/app/api/import/ical/route.ts
@@ -1,0 +1,297 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import ICAL from "ical.js";
+import { Prisma } from "@prisma/client";
+import { randomUUID } from "crypto";
+
+import { authenticateRequest } from "@/lib/auth/api-auth";
+import { logger } from "@/lib/logger";
+import { prisma } from "@/lib/prisma";
+
+const LOG_SOURCE = "import-ical-api";
+
+interface ImportPayload {
+  feedName?: string;
+  color?: string | null;
+  icalData?: string;
+  icalUrl?: string;
+}
+
+interface ParsedEvent {
+  baseUid: string;
+  externalEventId: string;
+  title: string;
+  description?: string;
+  start: Date;
+  end: Date;
+  location?: string;
+  allDay: boolean;
+  recurrenceRule?: string;
+  status?: string;
+  sequence?: number;
+  created?: Date;
+  lastModified?: Date;
+  isMaster: boolean;
+  isRecurring: boolean;
+  masterUid?: string;
+}
+
+interface ParsedCalendar {
+  events: ParsedEvent[];
+  calendarName?: string;
+  calendarColor?: string;
+}
+
+function parseIcalData(icalData: string): ParsedCalendar {
+  try {
+    const jcalData = ICAL.parse(icalData);
+    const vcalendar = new ICAL.Component(jcalData);
+    const vevents = vcalendar.getAllSubcomponents("vevent");
+
+    if (!vevents.length) {
+      throw new Error("Keine Termine in den iCal-Daten gefunden");
+    }
+
+    const calendarName = vcalendar.getFirstPropertyValue("x-wr-calname");
+    const calendarColor = vcalendar.getFirstPropertyValue("x-wr-calcolor");
+
+    const events: ParsedEvent[] = vevents.map((vevent) => {
+      const event = new ICAL.Event(vevent);
+      const baseUid = event.uid || randomUUID();
+
+      if (!event.startDate) {
+        throw new Error(`Termin ohne Startzeit gefunden (${baseUid})`);
+      }
+
+      const start = event.startDate.toJSDate();
+      let end: Date;
+      if (event.endDate) {
+        end = event.endDate.toJSDate();
+      } else if (event.duration) {
+        const calculatedEnd = event.startDate.clone();
+        calculatedEnd.addDuration(event.duration);
+        end = calculatedEnd.toJSDate();
+      } else {
+        end = new Date(start.getTime() + 60 * 60 * 1000);
+      }
+
+      const recurrenceRuleValue = vevent.getFirstPropertyValue("rrule") as
+        | ICAL.Recur
+        | undefined;
+      const recurrenceRule = recurrenceRuleValue
+        ? recurrenceRuleValue.toString()
+        : undefined;
+
+      const hasRecurrenceId = vevent.hasProperty("recurrence-id");
+      const recurrenceIdValue = hasRecurrenceId
+        ? (vevent.getFirstPropertyValue("recurrence-id") as
+            | ICAL.Time
+            | undefined)
+        : undefined;
+      const recurrenceId = recurrenceIdValue
+        ? recurrenceIdValue.toString()
+        : undefined;
+
+      const createdValue = vevent.getFirstPropertyValue("created") as
+        | ICAL.Time
+        | undefined;
+      const lastModifiedValue = vevent.getFirstPropertyValue("last-modified") as
+        | ICAL.Time
+        | undefined;
+      const sequenceValue = vevent.getFirstPropertyValue("sequence");
+      const sequence =
+        typeof sequenceValue === "number" ? sequenceValue : undefined;
+
+      return {
+        baseUid,
+        externalEventId:
+          hasRecurrenceId && recurrenceId
+            ? `${baseUid}-${recurrenceId}`
+            : baseUid,
+        title: event.summary || "Unbenannter Termin",
+        description: event.description || undefined,
+        start,
+        end,
+        location: event.location || undefined,
+        allDay: event.startDate.isDate,
+        recurrenceRule,
+        status: (vevent.getFirstPropertyValue("status") as string | undefined) || undefined,
+        sequence,
+        created: createdValue ? createdValue.toJSDate() : undefined,
+        lastModified: lastModifiedValue
+          ? lastModifiedValue.toJSDate()
+          : undefined,
+        isMaster: !!recurrenceRule && !hasRecurrenceId,
+        isRecurring: !!recurrenceRule && !hasRecurrenceId,
+        masterUid: hasRecurrenceId ? baseUid : undefined,
+      } satisfies ParsedEvent;
+    });
+
+    return {
+      events,
+      calendarName: calendarName ? String(calendarName) : undefined,
+      calendarColor: calendarColor ? String(calendarColor) : undefined,
+    };
+  } catch (error) {
+    logger.error(
+      "Fehler beim Parsen der iCal-Daten",
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+      LOG_SOURCE
+    );
+    throw error;
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await authenticateRequest(request, LOG_SOURCE);
+    if ("response" in auth) {
+      return auth.response;
+    }
+
+    const payload = (await request.json()) as ImportPayload;
+
+    if (!payload.icalData && !payload.icalUrl) {
+      return NextResponse.json(
+        { error: "Es wurden keine iCal-Daten übermittelt" },
+        { status: 400 }
+      );
+    }
+
+    let icalData = payload.icalData;
+
+    if (!icalData && payload.icalUrl) {
+      try {
+        const response = await fetch(payload.icalUrl);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        icalData = await response.text();
+      } catch (error) {
+        logger.error(
+          "Fehler beim Laden der iCal-URL",
+          {
+            url: payload.icalUrl,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          LOG_SOURCE
+        );
+        return NextResponse.json(
+          { error: "Die iCal-Datei konnte nicht geladen werden" },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (!icalData) {
+      return NextResponse.json(
+        { error: "Die iCal-Daten sind leer" },
+        { status: 400 }
+      );
+    }
+
+    const parsed = parseIcalData(icalData);
+
+    const feedName =
+      payload.feedName?.trim() || parsed.calendarName || "Importierter Kalender";
+    const feedColor = payload.color || parsed.calendarColor || null;
+
+    const feed = await prisma.calendarFeed.create({
+      data: {
+        name: feedName,
+        color: feedColor,
+        type: "LOCAL",
+        enabled: true,
+        userId: auth.userId,
+      },
+    });
+
+    const masterMap = new Map<string, string>();
+    let imported = 0;
+
+    const events = [...parsed.events].sort((a, b) => {
+      if (a.isMaster && !b.isMaster) return -1;
+      if (!a.isMaster && b.isMaster) return 1;
+      return 0;
+    });
+
+    for (const event of events) {
+      try {
+        const masterEventId = event.masterUid
+          ? masterMap.get(event.masterUid) || null
+          : null;
+
+        const createdEvent = await prisma.calendarEvent.create({
+          data: {
+            feedId: feed.id,
+            externalEventId: event.externalEventId,
+            title: event.title,
+            description: event.description,
+            start: event.start,
+            end: event.end,
+            location: event.location,
+            isRecurring: event.isRecurring,
+            recurrenceRule: event.recurrenceRule,
+            allDay: event.allDay,
+            status: event.status,
+            sequence: event.sequence,
+            created: event.created,
+            lastModified: event.lastModified,
+            isMaster: event.isMaster,
+            masterEventId,
+            recurringEventId: event.masterUid || null,
+            organizer: Prisma.JsonNull,
+            attendees: Prisma.JsonNull,
+          },
+        });
+
+        if (event.isMaster) {
+          masterMap.set(event.baseUid, createdEvent.id);
+        }
+
+        imported += 1;
+      } catch (error) {
+        logger.error(
+          "Fehler beim Speichern eines Termins",
+          {
+            feedId: feed.id,
+            externalEventId: event.externalEventId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          LOG_SOURCE
+        );
+      }
+    }
+
+    logger.info(
+      "iCal-Import abgeschlossen",
+      {
+        feedId: feed.id,
+        imported,
+      },
+      LOG_SOURCE
+    );
+
+    return NextResponse.json({
+      feedId: feed.id,
+      imported,
+      feedName,
+    });
+  } catch (error) {
+    logger.error(
+      "Unerwarteter Fehler beim iCal-Import",
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+      LOG_SOURCE
+    );
+
+    return NextResponse.json(
+      { error: "Der iCal-Import ist fehlgeschlagen" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/src/app/api/import/ical/route.ts
+++ b/src/app/api/import/ical/route.ts
@@ -590,110 +590,121 @@ export async function POST(request: NextRequest) {
     const desiredColor =
       sanitizeColor(payload.color) ?? parsed.calendarColor ?? null;
 
+    const orderedEvents = [...parsed.events].sort((a, b) => {
+      if (a.isMaster && !b.isMaster) return -1;
+      if (!a.isMaster && b.isMaster) return 1;
+      return a.start.getTime() - b.start.getTime();
+    });
+
+    const externalIdsToReplace = Array.from(
+      new Set(
+        orderedEvents
+          .map((event) => event.externalEventId?.trim())
+          .filter((id): id is string => typeof id === "string" && id.length > 0)
+      )
+    );
+
     const { feed, imported, skipped } = await prisma.$transaction(
       async (tx) => {
-      const resolvedFeed =
-        targetFeed ??
-        (await tx.calendarFeed.create({
-          data: {
-            name: feedName,
-            color: desiredColor ?? "#3b82f6",
-            type: "LOCAL",
-            enabled: true,
-            userId: auth.userId,
-          },
-        }));
-
-      const masterMap = new Map<string, string>();
-      let importedCount = 0;
-
-      const events = [...parsed.events].sort((a, b) => {
-        if (a.isMaster && !b.isMaster) return -1;
-        if (!a.isMaster && b.isMaster) return 1;
-        return a.start.getTime() - b.start.getTime();
-      });
-
-      let storageFailures = 0;
-
-      for (const event of events) {
-        try {
-          if (event.externalEventId) {
-            await tx.calendarEvent.deleteMany({
-              where: {
-                feedId: resolvedFeed.id,
-                externalEventId: event.externalEventId,
-              },
-            });
-          }
-
-          const masterEventId = event.masterUid
-            ? masterMap.get(event.masterUid) || null
-            : null;
-
-          const createdEvent = await tx.calendarEvent.create({
+        const resolvedFeed =
+          targetFeed ??
+          (await tx.calendarFeed.create({
             data: {
+              name: feedName,
+              color: desiredColor ?? "#3b82f6",
+              type: "LOCAL",
+              enabled: true,
+              userId: auth.userId,
+            },
+          }));
+
+        if (externalIdsToReplace.length) {
+          await tx.calendarEvent.deleteMany({
+            where: {
               feedId: resolvedFeed.id,
-              externalEventId: event.externalEventId,
-              title: event.title,
-              description: event.description,
-              start: event.start,
-              end: event.end,
-              location: event.location,
-              isRecurring: event.isRecurring,
-              recurrenceRule: event.recurrenceRule,
-              allDay: event.allDay,
-              status: event.status,
-              sequence: event.sequence,
-              created: event.created,
-              lastModified: event.lastModified,
-              isMaster: event.isMaster,
-              masterEventId,
-              recurringEventId: event.isRecurring
-                ? event.isMaster
-                  ? event.baseUid
-                  : event.masterUid || event.baseUid
-                : null,
-              organizer: event.organizer
-                ? {
-                    name: event.organizer.name,
-                    email: event.organizer.email,
-                  }
-                : undefined,
-              attendees: event.attendees?.length
-                ? event.attendees.map((attendee) => ({
-                    name: attendee.name,
-                    email: attendee.email,
-                    status: attendee.status,
-                  }))
-                : undefined,
+              externalEventId: { in: externalIdsToReplace },
             },
           });
-
-          if (event.isMaster) {
-            masterMap.set(event.baseUid, createdEvent.id);
-          }
-
-          importedCount += 1;
-        } catch (error) {
-          storageFailures += 1;
-          logger.error(
-            "Fehler beim Speichern eines Termins",
-            {
-              feedId: resolvedFeed.id,
-              externalEventId: event.externalEventId,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            LOG_SOURCE
-          );
         }
-      }
 
-      return {
-        feed: resolvedFeed,
-        imported: importedCount,
-        skipped: parsed.skipped + storageFailures,
-      };
-    }
+        const masterMap = new Map<string, string>();
+        let importedCount = 0;
+        let storageFailures = 0;
+
+        for (const event of orderedEvents) {
+          try {
+            const masterEventId = event.masterUid
+              ? masterMap.get(event.masterUid) || null
+              : null;
+
+            const createdEvent = await tx.calendarEvent.create({
+              data: {
+                feedId: resolvedFeed.id,
+                externalEventId: event.externalEventId,
+                title: event.title,
+                description: event.description,
+                start: event.start,
+                end: event.end,
+                location: event.location,
+                isRecurring: event.isRecurring,
+                recurrenceRule: event.recurrenceRule,
+                allDay: event.allDay,
+                status: event.status,
+                sequence: event.sequence,
+                created: event.created,
+                lastModified: event.lastModified,
+                isMaster: event.isMaster,
+                masterEventId,
+                recurringEventId: event.isRecurring
+                  ? event.isMaster
+                    ? event.baseUid
+                    : event.masterUid || event.baseUid
+                  : null,
+                organizer: event.organizer
+                  ? {
+                      name: event.organizer.name,
+                      email: event.organizer.email,
+                    }
+                  : undefined,
+                attendees: event.attendees?.length
+                  ? event.attendees.map((attendee) => ({
+                      name: attendee.name,
+                      email: attendee.email,
+                      status: attendee.status,
+                    }))
+                  : undefined,
+              },
+            });
+
+            if (event.isMaster) {
+              masterMap.set(event.baseUid, createdEvent.id);
+            }
+
+            importedCount += 1;
+          } catch (error) {
+            storageFailures += 1;
+            logger.error(
+              "Fehler beim Speichern eines Termins",
+              {
+                feedId: resolvedFeed.id,
+                externalEventId: event.externalEventId,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              LOG_SOURCE
+            );
+          }
+        }
+
+        return {
+          feed: resolvedFeed,
+          imported: importedCount,
+          skipped: parsed.skipped + storageFailures,
+        };
+      },
+      {
+        maxWait: 10_000,
+        timeout: 120_000,
+      }
     );
 
     logger.info(

--- a/src/app/api/import/ical/route.ts
+++ b/src/app/api/import/ical/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import ICAL from "ical.js";
-import { Prisma } from "@prisma/client";
 import { randomUUID } from "crypto";
 
 import { authenticateRequest } from "@/lib/auth/api-auth";
@@ -10,9 +9,12 @@ import { prisma } from "@/lib/prisma";
 
 const LOG_SOURCE = "import-ical-api";
 
+export const runtime = "nodejs";
+
 interface ImportPayload {
   feedName?: string;
   color?: string | null;
+  feedId?: string;
   icalData?: string;
   icalUrl?: string;
 }
@@ -122,7 +124,7 @@ function parseIcalData(icalData: string): ParsedCalendar {
           ? lastModifiedValue.toJSDate()
           : undefined,
         isMaster: !!recurrenceRule && !hasRecurrenceId,
-        isRecurring: !!recurrenceRule && !hasRecurrenceId,
+        isRecurring: !!recurrenceRule || hasRecurrenceId,
         masterUid: hasRecurrenceId ? baseUid : undefined,
       } satisfies ParsedEvent;
     });
@@ -160,6 +162,43 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    let targetFeed = null as Awaited<
+      ReturnType<typeof prisma.calendarFeed.findFirst>
+    >;
+
+    if (payload.feedId) {
+      targetFeed = await prisma.calendarFeed.findFirst({
+        where: {
+          id: payload.feedId,
+          OR: [
+            { userId: auth.userId },
+            {
+              account: {
+                userId: auth.userId,
+              },
+            },
+          ],
+        },
+      });
+
+      if (!targetFeed) {
+        return NextResponse.json(
+          { error: "Der ausgewählte Kalender wurde nicht gefunden" },
+          { status: 404 }
+        );
+      }
+
+      if (targetFeed.type !== "CALDAV" && targetFeed.type !== "LOCAL") {
+        return NextResponse.json(
+          {
+            error:
+              "In diesen Kalender können keine iCal-Termine importiert werden",
+          },
+          { status: 400 }
+        );
+      }
+    }
+
     let icalData = payload.icalData;
 
     if (!icalData && payload.icalUrl) {
@@ -192,78 +231,114 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const parsed = parseIcalData(icalData);
+    let parsed: ParsedCalendar;
+    try {
+      parsed = parseIcalData(icalData);
+    } catch (error) {
+      return NextResponse.json(
+        {
+          error:
+            error instanceof Error
+              ? error.message
+              : "Die iCal-Daten konnten nicht verarbeitet werden",
+        },
+        { status: 400 }
+      );
+    }
+
+    const parsedCalendarName = parsed.calendarName
+      ? String(parsed.calendarName).trim()
+      : undefined;
 
     const feedName =
-      payload.feedName?.trim() || parsed.calendarName || "Importierter Kalender";
-    const feedColor = payload.color || parsed.calendarColor || null;
+      payload.feedName?.trim() || parsedCalendarName || "Importierter Kalender";
 
-    const feed = await prisma.calendarFeed.create({
-      data: {
-        name: feedName,
-        color: feedColor,
-        type: "LOCAL",
-        enabled: true,
-        userId: auth.userId,
-      },
-    });
-
-    const masterMap = new Map<string, string>();
-    let imported = 0;
-
-    const events = [...parsed.events].sort((a, b) => {
-      if (a.isMaster && !b.isMaster) return -1;
-      if (!a.isMaster && b.isMaster) return 1;
-      return 0;
-    });
-
-    for (const event of events) {
-      try {
-        const masterEventId = event.masterUid
-          ? masterMap.get(event.masterUid) || null
+    const desiredColor =
+      typeof payload.color === "string" && payload.color.trim().length > 0
+        ? payload.color.trim()
+        : parsed.calendarColor && String(parsed.calendarColor).trim().length > 0
+          ? String(parsed.calendarColor).trim()
           : null;
 
-        const createdEvent = await prisma.calendarEvent.create({
+    const { feed, imported } = await prisma.$transaction(async (tx) => {
+      const resolvedFeed =
+        targetFeed ??
+        (await tx.calendarFeed.create({
           data: {
-            feedId: feed.id,
-            externalEventId: event.externalEventId,
-            title: event.title,
-            description: event.description,
-            start: event.start,
-            end: event.end,
-            location: event.location,
-            isRecurring: event.isRecurring,
-            recurrenceRule: event.recurrenceRule,
-            allDay: event.allDay,
-            status: event.status,
-            sequence: event.sequence,
-            created: event.created,
-            lastModified: event.lastModified,
-            isMaster: event.isMaster,
-            masterEventId,
-            recurringEventId: event.masterUid || null,
-            organizer: Prisma.JsonNull,
-            attendees: Prisma.JsonNull,
+            name: feedName,
+            color: desiredColor,
+            type: "LOCAL",
+            enabled: true,
+            userId: auth.userId,
           },
-        });
+        }));
 
-        if (event.isMaster) {
-          masterMap.set(event.baseUid, createdEvent.id);
+      const masterMap = new Map<string, string>();
+      let importedCount = 0;
+
+      const events = [...parsed.events].sort((a, b) => {
+        if (a.isMaster && !b.isMaster) return -1;
+        if (!a.isMaster && b.isMaster) return 1;
+        return 0;
+      });
+
+      for (const event of events) {
+        try {
+          if (event.externalEventId) {
+            await tx.calendarEvent.deleteMany({
+              where: {
+                feedId: resolvedFeed.id,
+                externalEventId: event.externalEventId,
+              },
+            });
+          }
+
+          const masterEventId = event.masterUid
+            ? masterMap.get(event.masterUid) || null
+            : null;
+
+          const createdEvent = await tx.calendarEvent.create({
+            data: {
+              feedId: resolvedFeed.id,
+              externalEventId: event.externalEventId,
+              title: event.title,
+              description: event.description,
+              start: event.start,
+              end: event.end,
+              location: event.location,
+              isRecurring: event.isRecurring,
+              recurrenceRule: event.recurrenceRule,
+              allDay: event.allDay,
+              status: event.status,
+              sequence: event.sequence,
+              created: event.created,
+              lastModified: event.lastModified,
+              isMaster: event.isMaster,
+              masterEventId,
+              recurringEventId: event.masterUid || null,
+            },
+          });
+
+          if (event.isMaster) {
+            masterMap.set(event.baseUid, createdEvent.id);
+          }
+
+          importedCount += 1;
+        } catch (error) {
+          logger.error(
+            "Fehler beim Speichern eines Termins",
+            {
+              feedId: resolvedFeed.id,
+              externalEventId: event.externalEventId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            LOG_SOURCE
+          );
         }
-
-        imported += 1;
-      } catch (error) {
-        logger.error(
-          "Fehler beim Speichern eines Termins",
-          {
-            feedId: feed.id,
-            externalEventId: event.externalEventId,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          LOG_SOURCE
-        );
       }
-    }
+
+      return { feed: resolvedFeed, imported: importedCount };
+    });
 
     logger.info(
       "iCal-Import abgeschlossen",
@@ -277,7 +352,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       feedId: feed.id,
       imported,
-      feedName,
+      feedName: feed.name,
     });
   } catch (error) {
     logger.error(

--- a/src/components/calendar/FeedManager.tsx
+++ b/src/components/calendar/FeedManager.tsx
@@ -83,7 +83,7 @@ export function FeedManager() {
               <div className="flex items-center gap-1">
                 <button
                   onClick={() => handleSyncFeed(feed.id)}
-                  disabled={syncingFeeds.has(feed.id)}
+                  disabled={feed.type === "LOCAL" || syncingFeeds.has(feed.id)}
                   className={cn(
                     "rounded-full p-1.5 text-muted-foreground hover:text-foreground",
                     "hover:bg-muted/50 focus:outline-none focus:ring-2",

--- a/src/components/settings/IcalImportSettings.tsx
+++ b/src/components/settings/IcalImportSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import { Loader2, Upload, Link as LinkIcon } from "lucide-react";
 import { toast } from "sonner";
@@ -15,6 +15,13 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 import { useCalendarStore } from "@/store/calendar";
 
@@ -31,8 +38,17 @@ export function IcalImportSettings() {
   const [color, setColor] = useState("#3b82f6");
   const [isImporting, setIsImporting] = useState(false);
   const [lastImported, setLastImported] = useState<ImportResponse | null>(null);
+  const [targetFeedId, setTargetFeedId] = useState<string>("new");
 
-  const { refreshEvents, refreshFeeds } = useCalendarStore();
+  const feeds = useCalendarStore((state) => state.feeds);
+  const refreshEvents = useCalendarStore((state) => state.refreshEvents);
+  const refreshFeeds = useCalendarStore((state) => state.refreshFeeds);
+
+  const importableFeeds = useMemo(
+    () =>
+      feeds.filter((feed) => feed.type === "CALDAV" || feed.type === "LOCAL"),
+    [feeds]
+  );
 
   const triggerImport = useCallback(
     async (payload: { icalData?: string; icalUrl?: string }) => {
@@ -49,8 +65,10 @@ export function IcalImportSettings() {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            feedName: feedName.trim() || undefined,
-            color,
+            feedName:
+              targetFeedId === "new" ? feedName.trim() || undefined : undefined,
+            color: targetFeedId === "new" ? color : undefined,
+            feedId: targetFeedId !== "new" ? targetFeedId : undefined,
             ...payload,
           }),
         });
@@ -66,6 +84,11 @@ export function IcalImportSettings() {
           `Kalender „${data.feedName}“ wurde importiert. ${data.imported} Termine hinzugefügt.`
         );
 
+        if (targetFeedId === "new") {
+          setTargetFeedId(data.feedId);
+          setFeedName(data.feedName);
+        }
+
         await Promise.all([refreshFeeds(), refreshEvents()]);
       } catch (error) {
         console.error("Failed to import iCal data", error);
@@ -76,7 +99,7 @@ export function IcalImportSettings() {
         setIsImporting(false);
       }
     },
-    [color, feedName, refreshEvents, refreshFeeds]
+    [color, feedName, refreshEvents, refreshFeeds, targetFeedId]
   );
 
   const handleImportClick = () => {
@@ -92,7 +115,7 @@ export function IcalImportSettings() {
     try {
       const text = await file.text();
 
-      if (!feedName.trim()) {
+      if (targetFeedId === "new" && !feedName.trim()) {
         const inferredName = file.name.replace(/\.ics$/i, "");
         setFeedName(inferredName);
       }
@@ -125,6 +148,32 @@ export function IcalImportSettings() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="target-feed">Zielkalender</Label>
+            <Select
+              value={targetFeedId}
+              onValueChange={setTargetFeedId}
+              disabled={isImporting}
+            >
+              <SelectTrigger id="target-feed">
+                <SelectValue placeholder="Kalender auswählen" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="new">Neuen lokalen Kalender anlegen</SelectItem>
+                {importableFeeds.map((feed) => (
+                  <SelectItem key={feed.id} value={feed.id}>
+                    {feed.name}
+                    {feed.type === "CALDAV" ? " (CalDAV)" : " (Lokal)"}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-sm text-muted-foreground">
+              Wählen Sie einen bestehenden CalDAV- oder lokalen Kalender aus,
+              oder legen Sie einen neuen lokalen Kalender für den Import an.
+            </p>
+          </div>
+
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="feed-name">Name des Kalenders</Label>
@@ -133,7 +182,7 @@ export function IcalImportSettings() {
                 placeholder="z. B. Uni Stundenplan"
                 value={feedName}
                 onChange={(event) => setFeedName(event.target.value)}
-                disabled={isImporting}
+                disabled={isImporting || targetFeedId !== "new"}
               />
             </div>
             <div className="space-y-2">
@@ -143,7 +192,7 @@ export function IcalImportSettings() {
                 type="color"
                 value={color}
                 onChange={(event) => setColor(event.target.value)}
-                disabled={isImporting}
+                disabled={isImporting || targetFeedId !== "new"}
                 className="h-10 w-full cursor-pointer"
               />
             </div>

--- a/src/components/settings/IcalImportSettings.tsx
+++ b/src/components/settings/IcalImportSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Loader2, Upload, Link as LinkIcon } from "lucide-react";
 import { toast } from "sonner";
@@ -29,6 +29,7 @@ interface ImportResponse {
   feedId: string;
   imported: number;
   feedName: string;
+  skipped?: number;
 }
 
 export function IcalImportSettings() {
@@ -43,12 +44,20 @@ export function IcalImportSettings() {
   const feeds = useCalendarStore((state) => state.feeds);
   const refreshEvents = useCalendarStore((state) => state.refreshEvents);
   const refreshFeeds = useCalendarStore((state) => state.refreshFeeds);
+  const loadFeedsOnceRef = useRef(false);
 
   const importableFeeds = useMemo(
     () =>
       feeds.filter((feed) => feed.type === "CALDAV" || feed.type === "LOCAL"),
     [feeds]
   );
+
+  useEffect(() => {
+    if (!loadFeedsOnceRef.current) {
+      loadFeedsOnceRef.current = true;
+      void refreshFeeds();
+    }
+  }, [refreshFeeds]);
 
   const triggerImport = useCallback(
     async (payload: { icalData?: string; icalUrl?: string }) => {
@@ -80,8 +89,12 @@ export function IcalImportSettings() {
 
         const data = (await response.json()) as ImportResponse;
         setLastImported(data);
+        const skippedInfo =
+          typeof data.skipped === "number" && data.skipped > 0
+            ? ` ${data.skipped} Termine konnten nicht übernommen werden.`
+            : "";
         toast.success(
-          `Kalender „${data.feedName}“ wurde importiert. ${data.imported} Termine hinzugefügt.`
+          `Kalender „${data.feedName}“ wurde importiert. ${data.imported} Termine hinzugefügt.${skippedInfo}`
         );
 
         if (targetFeedId === "new") {
@@ -158,17 +171,28 @@ export function IcalImportSettings() {
               <SelectTrigger id="target-feed">
                 <SelectValue placeholder="Kalender auswählen" />
               </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="new">Neuen lokalen Kalender anlegen</SelectItem>
-                {importableFeeds.map((feed) => (
-                  <SelectItem key={feed.id} value={feed.id}>
-                    {feed.name}
-                    {feed.type === "CALDAV" ? " (CalDAV)" : " (Lokal)"}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <p className="text-sm text-muted-foreground">
+            <SelectContent>
+              <SelectItem value="new">Neuen lokalen Kalender anlegen</SelectItem>
+              {importableFeeds.map((feed) => (
+                <SelectItem key={feed.id} value={feed.id}>
+                  <span className="flex items-center gap-2">
+                    {feed.color ? (
+                      <span
+                        aria-hidden
+                        className="h-2 w-2 rounded-full"
+                        style={{ backgroundColor: feed.color }}
+                      />
+                    ) : null}
+                    <span className="truncate">
+                      {feed.name}
+                      {feed.type === "CALDAV" ? " (CalDAV)" : " (Lokal)"}
+                    </span>
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-sm text-muted-foreground">
               Wählen Sie einen bestehenden CalDAV- oder lokalen Kalender aus,
               oder legen Sie einen neuen lokalen Kalender für den Import an.
             </p>
@@ -250,7 +274,7 @@ export function IcalImportSettings() {
             </div>
             <p className="text-sm text-muted-foreground">
               Unterstützt Standard-iCal-Dateien (.ics). Die Termine werden in
-              einen neuen lokalen Kalender importiert.
+              den ausgewählten Kalender übernommen.
             </p>
           </div>
 
@@ -261,6 +285,12 @@ export function IcalImportSettings() {
                 {" "}
                 Terminen.
               </p>
+              {typeof lastImported.skipped === "number" && lastImported.skipped > 0 ? (
+                <p className="text-muted-foreground">
+                  {lastImported.skipped} Einträge konnten nicht importiert werden
+                  (siehe Protokoll).
+                </p>
+              ) : null}
             </div>
           )}
         </CardContent>

--- a/src/components/settings/IcalImportSettings.tsx
+++ b/src/components/settings/IcalImportSettings.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import { Loader2, Upload, Link as LinkIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import { useCalendarStore } from "@/store/calendar";
+
+interface ImportResponse {
+  feedId: string;
+  imported: number;
+  feedName: string;
+}
+
+export function IcalImportSettings() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [feedName, setFeedName] = useState("");
+  const [icalUrl, setIcalUrl] = useState("");
+  const [color, setColor] = useState("#3b82f6");
+  const [isImporting, setIsImporting] = useState(false);
+  const [lastImported, setLastImported] = useState<ImportResponse | null>(null);
+
+  const { refreshEvents, refreshFeeds } = useCalendarStore();
+
+  const triggerImport = useCallback(
+    async (payload: { icalData?: string; icalUrl?: string }) => {
+      if (!payload.icalData && !payload.icalUrl) {
+        toast.error("Bitte geben Sie entweder eine iCal-Datei oder einen Link an.");
+        return;
+      }
+
+      setIsImporting(true);
+      try {
+        const response = await fetch("/api/import/ical", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            feedName: feedName.trim() || undefined,
+            color,
+            ...payload,
+          }),
+        });
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({ error: undefined }));
+          throw new Error(data.error || "Import fehlgeschlagen");
+        }
+
+        const data = (await response.json()) as ImportResponse;
+        setLastImported(data);
+        toast.success(
+          `Kalender „${data.feedName}“ wurde importiert. ${data.imported} Termine hinzugefügt.`
+        );
+
+        await Promise.all([refreshFeeds(), refreshEvents()]);
+      } catch (error) {
+        console.error("Failed to import iCal data", error);
+        toast.error(
+          error instanceof Error ? error.message : "Import fehlgeschlagen"
+        );
+      } finally {
+        setIsImporting(false);
+      }
+    },
+    [color, feedName, refreshEvents, refreshFeeds]
+  );
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+
+      if (!feedName.trim()) {
+        const inferredName = file.name.replace(/\.ics$/i, "");
+        setFeedName(inferredName);
+      }
+
+      await triggerImport({ icalData: text });
+    } finally {
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
+
+  const handleUrlImport = async () => {
+    if (!icalUrl.trim()) {
+      toast.error("Bitte geben Sie einen gültigen iCal-Link ein.");
+      return;
+    }
+
+    await triggerImport({ icalUrl: icalUrl.trim() });
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>iCal Import</CardTitle>
+          <CardDescription>
+            Importieren Sie Termine aus einer iCal-Datei oder einem iCal-Link in
+            Ihren Fluid Calendar.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="feed-name">Name des Kalenders</Label>
+              <Input
+                id="feed-name"
+                placeholder="z. B. Uni Stundenplan"
+                value={feedName}
+                onChange={(event) => setFeedName(event.target.value)}
+                disabled={isImporting}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="feed-color">Farbe</Label>
+              <Input
+                id="feed-color"
+                type="color"
+                value={color}
+                onChange={(event) => setColor(event.target.value)}
+                disabled={isImporting}
+                className="h-10 w-full cursor-pointer"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="ical-url">iCal-Link</Label>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Input
+                id="ical-url"
+                placeholder="https://example.de/stundenplan.ics"
+                value={icalUrl}
+                onChange={(event) => setIcalUrl(event.target.value)}
+                disabled={isImporting}
+              />
+              <Button
+                onClick={handleUrlImport}
+                disabled={isImporting}
+                className="flex items-center gap-2"
+              >
+                {isImporting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <LinkIcon className="h-4 w-4" />
+                )}
+                Aus Link importieren
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>iCal-Datei</Label>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleImportClick}
+                disabled={isImporting}
+                className="flex items-center gap-2"
+              >
+                {isImporting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Upload className="h-4 w-4" />
+                )}
+                Datei auswählen
+              </Button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".ics"
+                onChange={handleFileChange}
+                className="hidden"
+              />
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Unterstützt Standard-iCal-Dateien (.ics). Die Termine werden in
+              einen neuen lokalen Kalender importiert.
+            </p>
+          </div>
+
+          {lastImported && (
+            <div className="rounded-md border border-muted-foreground/20 bg-muted p-4 text-sm">
+              <p className="font-medium">
+                Letzter Import: „{lastImported.feedName}“ mit {lastImported.imported}
+                {" "}
+                Terminen.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/src/lib/caldav-calendar.ts
+++ b/src/lib/caldav-calendar.ts
@@ -19,6 +19,21 @@ import {
 
 const LOG_SOURCE = "CalDAVCalendar";
 
+function buildEventUrl(calendarPath: string, eventId: string): {
+  normalizedCalendarPath: string;
+  eventUrl: string;
+} {
+  const normalizedCalendarPath = calendarPath.endsWith("/")
+    ? calendarPath.slice(0, -1)
+    : calendarPath;
+  const safeEventId = encodeURIComponent(eventId);
+
+  return {
+    normalizedCalendarPath,
+    eventUrl: `${normalizedCalendarPath}/${safeEventId}.ics`,
+  };
+}
+
 /**
  * Service for interacting with CalDAV servers
  */
@@ -532,13 +547,10 @@ export class CalDAVCalendarService {
       const client = await this.getClient();
 
       // For Fastmail compatibility, we'll use a PUT request to a specific URL
-      // Ensure the calendar path doesn't have a trailing slash
-      const normalizedCalendarPath = calendarPath.endsWith("/")
-        ? calendarPath.slice(0, -1)
-        : calendarPath;
-
-      // Create a URL for the event using the externalEventId
-      const eventUrl = `${normalizedCalendarPath}/${externalEventId}.ics`;
+      const { normalizedCalendarPath, eventUrl } = buildEventUrl(
+        calendarPath,
+        externalEventId
+      );
 
       // Generate the iCalendar data
       const icalData = this.convertToICalendar({
@@ -741,13 +753,10 @@ export class CalDAVCalendarService {
       const client = await this.getClient();
 
       // For Fastmail compatibility, we'll use a DELETE request to a specific URL
-      // Ensure the calendar path doesn't have a trailing slash
-      const normalizedCalendarPath = calendarPath.endsWith("/")
-        ? calendarPath.slice(0, -1)
-        : calendarPath;
-
-      // Create a URL for the event using the externalEventId
-      const eventUrl = `${normalizedCalendarPath}/${externalEventId}.ics`;
+      const { normalizedCalendarPath, eventUrl } = buildEventUrl(
+        calendarPath,
+        externalEventId
+      );
 
       let response;
       try {
@@ -1025,13 +1034,7 @@ export class CalDAVCalendarService {
       const client = await this.getClient();
 
       // For Fastmail compatibility, we'll use a PUT request to a specific URL
-      // Ensure the calendar path doesn't have a trailing slash
-      const normalizedCalendarPath = calendarPath.endsWith("/")
-        ? calendarPath.slice(0, -1)
-        : calendarPath;
-
-      // Create a URL for the event using the UID
-      const eventUrl = `${normalizedCalendarPath}/${eventId}.ics`;
+      const { eventUrl } = buildEventUrl(calendarPath, eventId);
 
       let response;
       try {
@@ -1068,7 +1071,7 @@ export class CalDAVCalendarService {
 
           // If PUT fails, fall back to the createObject method
           response = await client.createObject({
-            url: calendarPath,
+            url: eventUrl,
             data: icalData,
             headers: {
               "Content-Type": "text/calendar; charset=utf-8",
@@ -1149,6 +1152,78 @@ export class CalDAVCalendarService {
           error: error instanceof Error ? error.message : "Unknown error",
           calendarPath,
           eventTitle: event.title,
+        },
+        LOG_SOURCE
+      );
+      throw error;
+    }
+  }
+
+  async putEvent(
+    calendarPath: string,
+    event: CalendarEventInput & { id: string }
+  ): Promise<void> {
+    const { eventUrl } = buildEventUrl(calendarPath, event.id);
+    const icalData = this.convertToICalendar(event);
+
+    try {
+      const response = await fetch(eventUrl, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "text/calendar; charset=utf-8",
+          Authorization:
+            "Basic " +
+            Buffer.from(
+              `${this.account.caldavUsername || this.account.email}:${
+                this.account.accessToken
+              }`
+            ).toString("base64"),
+        },
+        body: icalData,
+      });
+
+      if (response.status >= 200 && response.status < 300) {
+        return;
+      }
+
+      logger.error(
+        "Server returned error status when storing event with PUT",
+        {
+          status: response.status,
+          statusText: response.statusText,
+          calendarPath,
+          eventId: event.id,
+          eventUrl,
+        },
+        LOG_SOURCE
+      );
+
+      const client = await this.getClient();
+      const fallback = await client.updateObject({
+        url: eventUrl,
+        data: icalData,
+        headers: {
+          "Content-Type": "text/calendar; charset=utf-8",
+        },
+      });
+
+      if (fallback.status < 200 || fallback.status >= 300) {
+        throw new Error(
+          `Failed to store event on server: ${
+            fallback.statusText || fallback.status
+          }`
+        );
+      }
+    } catch (error) {
+      logger.error(
+        "Failed to store event on CalDAV server",
+        {
+          error:
+            error instanceof Error ? error.message : "Unknown error",
+          stack:
+            error instanceof Error && error.stack ? error.stack : null,
+          calendarPath,
+          eventId: event.id,
         },
         LOG_SOURCE
       );

--- a/src/lib/calendar-db.ts
+++ b/src/lib/calendar-db.ts
@@ -38,7 +38,7 @@ export async function getEvent(
     recurringEventId: event.recurringEventId || undefined,
     feed: {
       ...event.feed,
-      type: event.feed.type as "GOOGLE" | "OUTLOOK" | "CALDAV",
+      type: event.feed.type as "GOOGLE" | "OUTLOOK" | "CALDAV" | "LOCAL",
       url: event.feed.url || undefined,
       color: event.feed.color || undefined,
       lastSync: event.feed.lastSync || undefined,

--- a/src/store/calendar.ts
+++ b/src/store/calendar.ts
@@ -88,7 +88,7 @@ interface CalendarStore extends CalendarState {
   addFeed: (
     name: string,
     url: string,
-    type: "GOOGLE" | "OUTLOOK" | "CALDAV",
+    type: "GOOGLE" | "OUTLOOK" | "CALDAV" | "LOCAL",
     color?: string
   ) => Promise<void>;
   removeFeed: (id: string) => Promise<void>;
@@ -280,7 +280,7 @@ export const useCalendarStore = create<CalendarStore>()((set, get) => ({
       set((state) => ({ feeds: [...state.feeds, feed] }));
 
       // Sync the feed's events
-      if (url) {
+      if (url && type !== "LOCAL") {
         await get().syncFeed(id);
       }
     } catch (error) {
@@ -778,6 +778,11 @@ export const useCalendarStore = create<CalendarStore>()((set, get) => ({
       // Get the feed to determine its type
       const feed = get().feeds.find((f) => f.id === feedId);
       if (!feed) throw new Error("Calendar not found");
+
+      if (feed.type === "LOCAL") {
+        // Local calendars are managed directly in the database and don't support remote sync
+        return;
+      }
 
       const endpoint =
         feed.type === "GOOGLE"

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -2,7 +2,7 @@ export interface CalendarFeed {
   id: string;
   name: string;
   url?: string; // Make optional since local calendar won't have URL
-  type: "GOOGLE" | "OUTLOOK" | "CALDAV";
+  type: "GOOGLE" | "OUTLOOK" | "CALDAV" | "LOCAL";
   color?: string;
   enabled: boolean;
   lastSync?: Date;


### PR DESCRIPTION
## Summary
- add a server-side import endpoint that parses iCal data into a new local calendar feed and events
- expose a new iCal Import tab in settings with UI to upload a file or import from a link and refresh calendar data
- extend calendar types and UI behaviour to handle LOCAL feeds and avoid syncing unsupported calendars

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e65a109bec8331961c15c30911690b