### PR TITLE
Ensure calendar updates persist flags and tags

### DIFF
--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -10,6 +10,7 @@ import { prisma } from "@/lib/prisma";
 import {
   buildEventMetadata,
   CalendarTagMetadata,
+  normalizeIncomingFlags,
 } from "@/lib/calendar-metadata";
 import { ensureTagProgressionSchema } from "@/lib/schema-guards";
 import {
@@ -144,10 +145,19 @@ export async function PATCH(
     const existingMetadata =
       (existingEvent as { metadata?: Prisma.JsonValue | null }).metadata ?? null;
 
+    const hasIncomingFlags =
+      metadataInput && typeof metadataInput === "object" && "flags" in metadataInput;
+    const normalizedFlags = hasIncomingFlags
+      ? normalizeIncomingFlags(
+          (metadataInput as { flags?: unknown }).flags ?? []
+        ) ?? []
+      : undefined;
+
     const metadataPayload = buildEventMetadata({
       existing: metadataInput ? null : existingMetadata,
       incoming: metadataInput ?? undefined,
       tags,
+      flags: normalizedFlags,
       feedType: existingEvent.feed.type,
     });
 
@@ -160,9 +170,12 @@ export async function PATCH(
         ? newDate(updates.end)
         : newDate(existingEvent.end ?? existingEvent.start);
 
-    const shouldSplit = hasConditionalLearningFlag(
-      metadataInput ?? metadataPayload ?? existingMetadata
-    );
+    const metadataForSplit =
+      normalizedFlags !== undefined
+        ? { ...(metadataInput ?? {}), flags: normalizedFlags }
+        : metadataInput ?? metadataPayload ?? existingMetadata;
+
+    const shouldSplit = hasConditionalLearningFlag(metadataForSplit);
 
     if (shouldSplit) {
       const created = await prisma.$transaction(async (tx) => {

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -160,7 +160,11 @@ export async function PATCH(
         ? newDate(updates.end)
         : newDate(existingEvent.end ?? existingEvent.start);
 
-    if (metadataInput && hasConditionalLearningFlag(metadataInput)) {
+    const shouldSplit = hasConditionalLearningFlag(
+      metadataInput ?? metadataPayload ?? existingMetadata
+    );
+
+    if (shouldSplit) {
       const created = await prisma.$transaction(async (tx) => {
         const events = await createConditionalLearningEvents({
           prisma: tx,

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -9,6 +9,7 @@ import { prisma } from "@/lib/prisma";
 import {
   buildEventMetadata,
   CalendarTagMetadata,
+  normalizeIncomingFlags,
 } from "@/lib/calendar-metadata";
 import {
   createConditionalLearningEvents,
@@ -153,19 +154,31 @@ export async function POST(request: NextRequest) {
       tags = [];
     }
 
+    const hasIncomingFlags =
+      metadataInput && typeof metadataInput === "object" && "flags" in metadataInput;
+    const normalizedFlags = hasIncomingFlags
+      ? normalizeIncomingFlags(
+          (metadataInput as { flags?: unknown }).flags ?? []
+        ) ?? []
+      : undefined;
+
     const metadataPayload = buildEventMetadata({
       existing: null,
       incoming: metadataInput ?? undefined,
       tags,
+      flags: normalizedFlags,
       feedType: feed.type,
     });
 
     const startDate = newDate(start);
     const endDate = newDate(end);
 
-    const shouldSplit = hasConditionalLearningFlag(
-      metadataInput ?? metadataPayload ?? undefined
-    );
+    const metadataForSplit =
+      normalizedFlags !== undefined
+        ? { ...(metadataInput ?? {}), flags: normalizedFlags }
+        : metadataInput ?? metadataPayload ?? undefined;
+
+    const shouldSplit = hasConditionalLearningFlag(metadataForSplit);
 
     if (shouldSplit) {
       const created = await prisma.$transaction((tx) =>
@@ -328,10 +341,19 @@ export async function PATCH(request: NextRequest) {
     const existingMetadata =
       (existingEvent as { metadata?: Prisma.JsonValue | null }).metadata ?? null;
 
+    const hasIncomingFlags =
+      metadataInput && typeof metadataInput === "object" && "flags" in metadataInput;
+    const normalizedFlags = hasIncomingFlags
+      ? normalizeIncomingFlags(
+          (metadataInput as { flags?: unknown }).flags ?? []
+        ) ?? []
+      : undefined;
+
     const metadataPayload = buildEventMetadata({
       existing: existingMetadata,
       incoming: metadataInput ?? undefined,
       tags,
+      flags: normalizedFlags,
       feedType: existingEvent.feed.type,
     });
 
@@ -340,9 +362,12 @@ export async function PATCH(request: NextRequest) {
       ? newDate(end)
       : newDate(existingEvent.end ?? existingEvent.start);
 
-    const shouldSplit = hasConditionalLearningFlag(
-      metadataInput ?? metadataPayload ?? existingMetadata
-    );
+    const metadataForSplit =
+      normalizedFlags !== undefined
+        ? { ...(metadataInput ?? {}), flags: normalizedFlags }
+        : metadataInput ?? metadataPayload ?? existingMetadata;
+
+    const shouldSplit = hasConditionalLearningFlag(metadataForSplit);
 
     if (shouldSplit) {
       const created = await prisma.$transaction(async (tx) => {

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -163,7 +163,9 @@ export async function POST(request: NextRequest) {
     const startDate = newDate(start);
     const endDate = newDate(end);
 
-    const shouldSplit = hasConditionalLearningFlag(metadataInput);
+    const shouldSplit = hasConditionalLearningFlag(
+      metadataInput ?? metadataPayload ?? undefined
+    );
 
     if (shouldSplit) {
       const created = await prisma.$transaction((tx) =>
@@ -294,11 +296,23 @@ export async function PATCH(request: NextRequest) {
 
     await ensureTagProgressionSchema();
 
+    const requestedTagIds = Array.isArray(tagIds)
+      ? tagIds
+      : Array.isArray(metadataInput?.tags)
+        ? metadataInput?.tags
+            .map((tag) =>
+              typeof tag === "object" && tag !== null && "id" in tag
+                ? String(tag.id)
+                : undefined
+            )
+            .filter((tagId): tagId is string => Boolean(tagId))
+        : undefined;
+
     let tags: CalendarTagMetadata[] | undefined;
-    if (Array.isArray(tagIds) && tagIds.length > 0) {
+    if (requestedTagIds && requestedTagIds.length > 0) {
       tags = await prisma.tag.findMany({
         where: {
-          id: { in: tagIds },
+          id: { in: requestedTagIds },
           userId,
         },
         select: {
@@ -326,7 +340,11 @@ export async function PATCH(request: NextRequest) {
       ? newDate(end)
       : newDate(existingEvent.end ?? existingEvent.start);
 
-    if (metadataInput && hasConditionalLearningFlag(metadataInput)) {
+    const shouldSplit = hasConditionalLearningFlag(
+      metadataInput ?? metadataPayload ?? existingMetadata
+    );
+
+    if (shouldSplit) {
       const created = await prisma.$transaction(async (tx) => {
         const events = await createConditionalLearningEvents({
           prisma: tx,

--- a/src/lib/__tests__/calendar-metadata.test.ts
+++ b/src/lib/__tests__/calendar-metadata.test.ts
@@ -1,0 +1,58 @@
+import { Prisma } from "@prisma/client";
+
+import {
+  buildEventMetadata,
+  normalizeIncomingFlags,
+} from "@/lib/calendar-metadata";
+
+describe("normalizeIncomingFlags", () => {
+  it("returns undefined when flags were not provided", () => {
+    expect(normalizeIncomingFlags(undefined)).toBeUndefined();
+  });
+
+  it("normalizes valid flags and removes duplicates", () => {
+    expect(
+      normalizeIncomingFlags([
+        "fixed",
+        "flexible",
+        "flexible",
+        "conditional-learning",
+        "unknown",
+      ])
+    ).toEqual(["fixed", "flexible", "conditional-learning"]);
+  });
+
+  it("treats null or invalid payloads as an explicit empty list", () => {
+    expect(normalizeIncomingFlags(null)).toEqual([]);
+    expect(normalizeIncomingFlags("fixed")).toEqual([]);
+  });
+});
+
+describe("buildEventMetadata", () => {
+  it("applies sanitized flags overrides when provided", () => {
+    const metadata = buildEventMetadata({
+      existing: { flags: ["fixed"], tags: [] },
+      incoming: { energyLevel: 3 },
+      tags: [],
+      flags: ["dopamine"],
+      feedType: "LOCAL",
+    });
+
+    expect((metadata as Prisma.JsonObject).flags).toEqual(["dopamine"]);
+    expect((metadata as Prisma.JsonObject).energyLevel).toBe(3);
+  });
+
+  it("filters invalid flags from existing payloads when no override provided", () => {
+    const metadata = buildEventMetadata({
+      existing: { flags: ["fixed", "invalid"] },
+      incoming: {
+        flags: ["conditional-learning", 42] as unknown,
+      } as unknown as Prisma.InputJsonObject,
+      feedType: "LOCAL",
+    });
+
+    expect((metadata as Prisma.JsonObject).flags).toEqual([
+      "conditional-learning",
+    ]);
+  });
+});

--- a/src/lib/__tests__/conditional-learning.test.ts
+++ b/src/lib/__tests__/conditional-learning.test.ts
@@ -1,0 +1,155 @@
+import { Prisma } from "@prisma/client";
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  createConditionalLearningEvents,
+  hasConditionalLearningFlag,
+} from "@/lib/conditional-learning";
+
+const FEED_ID = "feed-1";
+
+function buildPrismaMock(blockers: unknown[] = []) {
+  const createMock = jest.fn().mockImplementation(({ data }) =>
+    Promise.resolve({
+      id: `event-${createMock.mock.calls.length + 1}`,
+      feedId: FEED_ID,
+      feed: {
+        id: FEED_ID,
+        name: "Local",
+        color: null,
+        type: "LOCAL",
+      },
+      ...data,
+    })
+  );
+
+  const prisma = {
+    calendarEvent: {
+      findMany: jest.fn().mockResolvedValue(blockers),
+      create: createMock,
+    },
+  } as unknown as PrismaClient;
+
+  return { prisma, createMock } as const;
+}
+
+describe("hasConditionalLearningFlag", () => {
+  it("detects conditional flag in input metadata", () => {
+    const metadata: Prisma.InputJsonObject = {
+      flags: ["conditional-learning", "flexible"],
+    };
+
+    expect(hasConditionalLearningFlag(metadata)).toBe(true);
+  });
+
+  it("detects conditional flag in stored metadata", () => {
+    const metadata: Prisma.JsonObject = {
+      flags: ["dopamine"],
+    };
+
+    expect(hasConditionalLearningFlag(metadata)).toBe(false);
+
+    metadata.flags = ["fixed", "conditional-learning"];
+    expect(hasConditionalLearningFlag(metadata)).toBe(true);
+  });
+
+  it("returns false for null-like metadata", () => {
+    expect(hasConditionalLearningFlag(null)).toBe(false);
+    expect(hasConditionalLearningFlag(Prisma.JsonNull)).toBe(false);
+  });
+});
+
+describe("createConditionalLearningEvents", () => {
+  it("splits a learning block around fixed blockers and annotates metadata", async () => {
+    const blockers = [
+      {
+        id: "fixed-1",
+        start: new Date("2024-01-01T08:00:00.000Z"),
+        end: new Date("2024-01-01T10:00:00.000Z"),
+        metadata: { flags: ["fixed"] },
+        feed: { type: "LOCAL" },
+      },
+      {
+        id: "fixed-2",
+        start: new Date("2024-01-01T11:00:00.000Z"),
+        end: new Date("2024-01-01T12:00:00.000Z"),
+        metadata: { flags: ["fixed"] },
+        feed: { type: "LOCAL" },
+      },
+    ];
+
+    const { prisma, createMock } = buildPrismaMock(blockers);
+
+    const start = new Date("2024-01-01T08:00:00.000Z");
+    const end = new Date("2024-01-01T17:00:00.000Z");
+    const metadata: Prisma.JsonObject = {
+      flags: ["conditional-learning"],
+      tags: [{ id: "tag-1", name: "Focus", color: "#fff" }],
+    };
+
+    const events = await createConditionalLearningEvents({
+      prisma,
+      userId: "user-1",
+      feedId: FEED_ID,
+      baseData: {
+        title: "Lernblock",
+        description: null,
+        location: null,
+        allDay: false,
+        isRecurring: false,
+      },
+      start,
+      end,
+      metadata,
+    });
+
+    expect(createMock).toHaveBeenCalledTimes(2);
+    expect(events).toHaveLength(2);
+
+    const firstCall = createMock.mock.calls[0]?.[0];
+    const secondCall = createMock.mock.calls[1]?.[0];
+
+    expect(firstCall?.data.start).toEqual(new Date("2024-01-01T10:00:00.000Z"));
+    expect(firstCall?.data.end).toEqual(new Date("2024-01-01T11:00:00.000Z"));
+    expect(secondCall?.data.start).toEqual(new Date("2024-01-01T12:00:00.000Z"));
+    expect(secondCall?.data.end).toEqual(new Date("2024-01-01T17:00:00.000Z"));
+
+    const firstMetadata = firstCall?.data.metadata as Prisma.JsonObject;
+    expect(firstMetadata.flags).toContain("conditional-learning");
+    expect(firstMetadata.segmentIndex).toBe(0);
+    expect(firstMetadata.segmentCount).toBe(2);
+    expect(firstMetadata.originalStart).toBe(start.toISOString());
+    expect(firstMetadata.originalEnd).toBe(end.toISOString());
+  });
+
+  it("returns no events when no qualifying gap exists", async () => {
+    const blockers = [
+      {
+        id: "fixed-1",
+        start: new Date("2024-01-01T08:00:00.000Z"),
+        end: new Date("2024-01-01T09:00:00.000Z"),
+        metadata: { flags: ["fixed"] },
+        feed: { type: "LOCAL" },
+      },
+    ];
+
+    const { prisma, createMock } = buildPrismaMock(blockers);
+
+    const events = await createConditionalLearningEvents({
+      prisma,
+      userId: "user-1",
+      feedId: FEED_ID,
+      baseData: {
+        title: "Kurzblock",
+        description: null,
+        location: null,
+      },
+      start: new Date("2024-01-01T08:00:00.000Z"),
+      end: new Date("2024-01-01T09:30:00.000Z"),
+      metadata: { flags: ["conditional-learning"] } as Prisma.JsonObject,
+    });
+
+    expect(events).toHaveLength(0);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/calendar-metadata.ts
+++ b/src/lib/calendar-metadata.ts
@@ -1,5 +1,7 @@
 import { Prisma } from "@prisma/client";
 
+import { EventFlag } from "@/types/calendar";
+
 export interface CalendarTagMetadata {
   id: string;
   name: string;
@@ -23,15 +25,48 @@ function cloneJsonObject(
   return { ...(value as Prisma.JsonObject) };
 }
 
+const VALID_FLAGS: readonly EventFlag[] = [
+  "fixed",
+  "flexible",
+  "conditional-learning",
+  "dopamine",
+] as const;
+
+const VALID_FLAG_SET = new Set<EventFlag>(VALID_FLAGS);
+
+function normalizeFlagList(flags: unknown): EventFlag[] | undefined {
+  if (!Array.isArray(flags)) {
+    return undefined;
+  }
+
+  const unique: EventFlag[] = [];
+  for (const entry of flags) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const candidate = entry as EventFlag;
+    if (!VALID_FLAG_SET.has(candidate)) {
+      continue;
+    }
+    if (!unique.includes(candidate)) {
+      unique.push(candidate);
+    }
+  }
+
+  return unique;
+}
+
 export function buildEventMetadata({
   existing,
   incoming,
   tags,
+  flags,
   feedType,
 }: {
   existing?: Prisma.JsonValue | null;
   incoming?: Prisma.InputJsonObject | null;
   tags?: CalendarTagMetadata[];
+  flags?: EventFlag[];
   feedType?: string | null;
 }): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput {
   if (incoming === null) {
@@ -56,9 +91,49 @@ export function buildEventMetadata({
     }
   }
 
+  if (flags !== undefined) {
+    next.flags = [...new Set(flags)];
+  } else if ("flags" in next) {
+    const normalized = normalizeFlagList((next as { flags?: unknown }).flags);
+    if (normalized) {
+      next.flags = normalized;
+    } else if (Array.isArray((next as { flags?: unknown }).flags)) {
+      next.flags = [];
+    } else {
+      delete next.flags;
+    }
+  }
+
   if (feedType) {
     next.feedType = feedType;
   }
 
   return next;
+}
+
+export function extractEventFlags(
+  metadata: Prisma.JsonValue | Prisma.InputJsonValue | null | undefined
+): EventFlag[] {
+  const payload = normalizeFlagList(
+    metadata && typeof metadata === "object"
+      ? (metadata as { flags?: unknown }).flags
+      : undefined
+  );
+
+  return payload ?? [];
+}
+
+export function normalizeIncomingFlags(
+  value: unknown
+): EventFlag[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return [];
+  }
+
+  const normalized = normalizeFlagList(value);
+  return normalized ?? [];
 }

--- a/src/lib/conditional-learning.ts
+++ b/src/lib/conditional-learning.ts
@@ -5,7 +5,11 @@ import { Prisma, PrismaClient } from "@prisma/client";
 const MIN_SEGMENT_MINUTES = 60;
 
 function isJsonNull(value: unknown): boolean {
-  return value === Prisma.JsonNull;
+  return (
+    value === Prisma.JsonNull ||
+    value === Prisma.DbNull ||
+    value === Prisma.AnyNull
+  );
 }
 
 type BaseEventData = {
@@ -25,7 +29,14 @@ type CalendarEventRecord = {
   feed?: { type?: string | null } | null;
 };
 
-function extractFlags(metadata: Prisma.JsonValue | null | undefined): string[] {
+function extractFlags(
+  metadata:
+    | Prisma.JsonValue
+    | Prisma.InputJsonValue
+    | Prisma.NullableJsonNullValueInput
+    | null
+    | undefined
+): string[] {
   if (!metadata || isJsonNull(metadata)) {
     return [];
   }
@@ -234,14 +245,12 @@ export async function createConditionalLearningEvents({
 }
 
 export function hasConditionalLearningFlag(
-  metadata: Prisma.InputJsonObject | null | undefined
+  metadata:
+    | Prisma.JsonValue
+    | Prisma.InputJsonValue
+    | Prisma.NullableJsonNullValueInput
+    | null
+    | undefined
 ): boolean {
-  if (!metadata) {
-    return false;
-  }
-  const flags = metadata.flags;
-  if (!Array.isArray(flags)) {
-    return false;
-  }
-  return flags.some((flag) => flag === "conditional-learning");
+  return extractFlags(metadata).some((flag) => flag === "conditional-learning");
 }


### PR DESCRIPTION
## Summary
- normalize metadata flag extraction so Prisma null markers no longer mask user-selected flags
- ensure both event endpoints recompute conditional-learning splits and resolve tag IDs from metadata when updating events
- add unit coverage around conditional learning splitting and flag detection logic

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e81ae0f42c8331aeb659e77df6e659