### PR TITLE
Fix XP award when saving completed tasks

### DIFF
--- a/src/app/(common)/tasks/page.tsx
+++ b/src/app/(common)/tasks/page.tsx
@@ -71,11 +71,27 @@ export default function TasksPage() {
   };
 
   const handleUpdateTask = async (task: NewTask) => {
-    if (selectedTask) {
-      await updateTask(selectedTask.id, task);
-      await fetchTasks();
-      await fetchProjects();
+    if (!selectedTask) {
+      return;
     }
+
+    const previousStatus = selectedTask.status;
+    const updatedTask = await updateTask(selectedTask.id, task);
+
+    if (
+      updatedTask &&
+      updatedTask.status === TaskStatus.COMPLETED &&
+      previousStatus !== TaskStatus.COMPLETED
+    ) {
+      const summary = useStatsStore
+        .getState()
+        .awardTaskCompletion(updatedTask);
+      showXpToast(summary);
+      mapTaskToSample(updatedTask);
+    }
+
+    await fetchTasks();
+    await fetchProjects();
   };
 
   const handleDeleteTask = async (taskId: string) => {


### PR DESCRIPTION
## Summary
- ensure editing a task to completed via the modal also awards XP and logs productivity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e82659914c83318d31ea2e558c45b8