### PR TITLE
Fix stats text boxes to prevent overflow

### DIFF
--- a/src/app/(common)/stats/page.tsx
+++ b/src/app/(common)/stats/page.tsx
@@ -17,6 +17,7 @@ import { StatsAvatar } from "@/components/stats/StatsAvatar";
 import { StatsDailyActivities } from "@/components/stats/StatsDailyActivities";
 import { StatsHistory } from "@/components/stats/StatsHistory";
 import { StatsProgress } from "@/components/stats/StatsProgress";
+import { StatsInfoBox } from "@/components/stats/StatsInfoBox";
 import { showXpToast } from "@/components/stats/showXpToast";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -148,23 +149,13 @@ export default function StatsPage() {
                   xpForNextLevel={Math.round(xpForNextLevel)}
                   lifetimeXp={Math.round(lifetimeXp)}
                 />
-                <div className="grid gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200/80 shadow-inner md:grid-cols-2">
-                  <div>
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-200/90">
-                      Aktueller Fokus
-                    </span>
-                    <p className="mt-1 text-sm text-slate-100/90">
-                      {STAT_DEFINITIONS[dominantStat].description}
-                    </p>
-                  </div>
-                  <div>
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-200/90">
-                      Streak
-                    </span>
-                    <p className="mt-1 text-sm text-slate-100/90">
-                      {currentStreak} Tage in Folge · Rekord: {longestStreak} Tage
-                    </p>
-                  </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  <StatsInfoBox label="Aktueller Fokus">
+                    {STAT_DEFINITIONS[dominantStat].description}
+                  </StatsInfoBox>
+                  <StatsInfoBox label="Streak">
+                    {currentStreak} Tage in Folge · Rekord: {longestStreak} Tage
+                  </StatsInfoBox>
                 </div>
                 {!avatarFinalized ? (
                   <div className="space-y-3 rounded-2xl border border-white/10 bg-slate-950/60 p-4">

--- a/src/components/stats/StatsDailyActivities.tsx
+++ b/src/components/stats/StatsDailyActivities.tsx
@@ -56,7 +56,7 @@ export function StatsDailyActivities({
             <div
               key={activity.id}
               className={cn(
-                "flex flex-col justify-between gap-3 rounded-lg border border-border/70 bg-background/50 p-4 shadow-sm transition hover:border-primary/50 hover:shadow-md md:flex-row md:items-center",
+                "flex flex-col justify-between gap-3 overflow-hidden rounded-lg border border-border/70 bg-background/50 p-4 shadow-sm transition hover:border-primary/50 hover:shadow-md md:flex-row md:items-center",
                 compact && "gap-2 rounded-xl p-3"
               )}
             >
@@ -66,7 +66,7 @@ export function StatsDailyActivities({
                 </div>
                 <div className="space-y-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <h4 className="text-base font-semibold text-foreground">
+                    <h4 className="break-words text-base font-semibold text-foreground">
                       {activity.label}
                     </h4>
                     <span
@@ -88,7 +88,7 @@ export function StatsDailyActivities({
                   </div>
                   <p
                     className={cn(
-                      "text-sm text-muted-foreground",
+                      "text-pretty text-sm text-muted-foreground break-words",
                       compact && "text-xs"
                     )}
                   >

--- a/src/components/stats/StatsHistory.tsx
+++ b/src/components/stats/StatsHistory.tsx
@@ -39,7 +39,7 @@ export function StatsHistory({ events, compact = false }: StatsHistoryProps) {
             <div
               key={event.id}
               className={cn(
-                "flex flex-col gap-2 rounded-lg border border-border/70 bg-background/60 p-4 shadow-sm md:flex-row md:items-center md:justify-between",
+                "flex flex-col gap-2 overflow-hidden rounded-lg border border-border/70 bg-background/60 p-4 shadow-sm md:flex-row md:items-center md:justify-between",
                 compact && "gap-1 rounded-xl p-3"
               )}
             >
@@ -47,9 +47,18 @@ export function StatsHistory({ events, compact = false }: StatsHistoryProps) {
                 <span className="text-sm font-semibold text-foreground">
                   {SOURCE_LABEL[event.source]}
                 </span>
-                <span className={cn("text-sm text-muted-foreground", compact && "text-xs")}>{event.label}</span>
+                <span
+                  className={cn(
+                    "text-pretty text-sm text-muted-foreground break-words",
+                    compact && "text-xs"
+                  )}
+                >
+                  {event.label}
+                </span>
                 {event.hypeText && (
-                  <span className="text-xs text-primary/80">{event.hypeText}</span>
+                  <span className="text-pretty text-xs text-primary/80 break-words">
+                    {event.hypeText}
+                  </span>
                 )}
                 <span className="text-xs text-muted-foreground">
                   {format(

--- a/src/components/stats/StatsInfoBox.tsx
+++ b/src/components/stats/StatsInfoBox.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface StatsInfoBoxProps {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function StatsInfoBox({ label, children, className }: StatsInfoBoxProps) {
+  const content =
+    typeof children === "string" || typeof children === "number" ? (
+      <p className="text-pretty text-sm leading-relaxed text-slate-100/90">
+        {children}
+      </p>
+    ) : (
+      children
+    );
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-2 overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-4 text-left text-slate-100/90 shadow-inner",
+        className
+      )}
+    >
+      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-200/80">
+        {label}
+      </p>
+      <div className="text-pretty text-sm leading-relaxed text-slate-100/90 [&>p]:m-0 [&>p]:text-pretty [&>p]:leading-relaxed [&>p]:text-slate-100/90">
+        {content}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `StatsInfoBox` component so the focus and streak callouts render inside padded boxes without overflowing
- tighten wrapping and overflow handling on daily activity and history cards to keep long labels and descriptions inside their containers

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e825ad7f34833188c3e1ba3054b8bb