### PR TITLE
Remove white backdrop from loading overlay

### DIFF
--- a/src/components/ui/loading-overlay.tsx
+++ b/src/components/ui/loading-overlay.tsx
@@ -1,6 +1,6 @@
 export function LoadingOverlay() {
   return (
-    <div className="absolute inset-0 z-50 flex items-center justify-center bg-white/80 backdrop-blur-sm">
+    <div className="absolute inset-0 z-50 flex items-center justify-center">
       <div className="h-8 w-8 animate-spin text-blue-600">
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           <circle


### PR DESCRIPTION
## Summary
- update the global loading overlay to stop rendering a white, blurred background
- keep the existing spinner so only the loading indicator is visible during busy states

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e827c877dc833185739a74c78ec25b