### PR TITLE
Restrict XP awards and add event feedback rescheduling

### DIFF
--- a/src/app/(common)/tasks/page.tsx
+++ b/src/app/(common)/tasks/page.tsx
@@ -98,8 +98,10 @@ export default function TasksPage() {
       const summary = useStatsStore
         .getState()
         .awardTaskCompletion(updatedTask);
-      showXpToast(summary);
-      mapTaskToSample(updatedTask);
+      if (summary) {
+        showXpToast(summary);
+        mapTaskToSample(updatedTask);
+      }
     }
 
     await fetchTasks();

--- a/src/components/calendar/EventQuickView.tsx
+++ b/src/components/calendar/EventQuickView.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import { HiCheck, HiPencil, HiTrash } from "react-icons/hi";
+import { HiCheck, HiPencil, HiTrash, HiX } from "react-icons/hi";
+import { toast } from "sonner";
 import {
   IoCalendarOutline,
   IoFlagOutline,
@@ -14,7 +15,14 @@ import {
   IoTimeOutline,
 } from "react-icons/io5";
 
-import { format, isFutureDate, newDate } from "@/lib/date-utils";
+import {
+  addDays,
+  addHours,
+  format,
+  formatToLocalISOString,
+  isFutureDate,
+  newDate,
+} from "@/lib/date-utils";
 import { mapEventToSample } from "@/lib/productivity";
 import { isTaskOverdue } from "@/lib/task-utils";
 import { cn } from "@/lib/utils";
@@ -25,11 +33,25 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
 import { showXpToast } from "@/components/stats/showXpToast";
 
 import { AttendeeStatus, CalendarEvent } from "@/types/calendar";
 import { Priority, Task, TaskStatus } from "@/types/task";
-import { useStatsStore } from "@/store/stats";
+import { useCalendarStore } from "@/store/calendar";
+import { getEventRewardKey, useStatsStore } from "@/store/stats";
 
 interface Attendee {
   name?: string;
@@ -68,6 +90,16 @@ const FLAG_LABELS: Record<string, string> = {
   dopamine: "Dopamin Boost",
 };
 
+type RescheduleOption = "none" | "1h" | "3h" | "1d" | "custom";
+
+const RESCHEDULE_CHOICES: Array<{ value: RescheduleOption; label: string }> = [
+  { value: "none", label: "Nicht verschieben" },
+  { value: "1h", label: "+1 Stunde" },
+  { value: "3h", label: "+3 Stunden" },
+  { value: "1d", label: "Morgen" },
+  { value: "custom", label: "Datum wählen" },
+];
+
 export function EventQuickView({
   isOpen,
   onClose,
@@ -81,6 +113,9 @@ export function EventQuickView({
   const awardEventCompletion = useStatsStore(
     (state) => state.awardEventCompletion
   );
+  const recordEventMissed = useStatsStore((state) => state.recordEventMissed);
+  const awardedEventIds = useStatsStore((state) => state.awardedEventIds);
+  const updateEvent = useCalendarStore((state) => state.updateEvent);
   const getStatusColor = (status: string | undefined) => {
     switch (status?.toUpperCase()) {
       case "ACCEPTED":
@@ -106,36 +141,224 @@ export function EventQuickView({
   const isPreparationReminder = Boolean(
     !isTask && eventItem?.extendedProps?.isPreparationReminder
   );
-  const [hasClaimedReward, setHasClaimedReward] = useState(false);
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const [feedbackText, setFeedbackText] = useState("");
+  const [rescheduleOption, setRescheduleOption] = useState<RescheduleOption>(
+    "none"
+  );
+  const [customReschedule, setCustomReschedule] = useState("");
+  const [isSubmittingFeedback, setIsSubmittingFeedback] = useState(false);
 
   useEffect(() => {
-    setHasClaimedReward(false);
+    setFeedbackOpen(false);
+    setFeedbackText("");
+    setRescheduleOption("none");
+    setCustomReschedule("");
+    setIsSubmittingFeedback(false);
   }, [item]);
 
+  useEffect(() => {
+    if (!feedbackOpen) {
+      setFeedbackText("");
+      setRescheduleOption("none");
+      setCustomReschedule("");
+      setIsSubmittingFeedback(false);
+    }
+  }, [feedbackOpen]);
+
+  const eventRewardKey = useMemo(() => {
+    if (!eventItem) return undefined;
+    return getEventRewardKey(eventItem);
+  }, [eventItem]);
+
+  const hasClaimedReward = Boolean(
+    eventRewardKey && awardedEventIds[eventRewardKey]
+  );
+
+  const eventDurationMinutes = useMemo(() => {
+    if (!eventItem) return 60;
+    const startDate = newDate(eventItem.start);
+    const endDate = eventItem.end
+      ? newDate(eventItem.end)
+      : eventItem.allDay
+        ? addHours(startDate, 24)
+        : addHours(startDate, 1);
+    let duration = Math.round(
+      Math.abs(endDate.getTime() - startDate.getTime()) / 60000
+    );
+    if (!Number.isFinite(duration) || duration <= 0) {
+      duration = eventItem.allDay ? 1440 : 60;
+    }
+    return Math.max(30, duration);
+  }, [eventItem]);
+
+  const handleRescheduleSelection = (option: RescheduleOption) => {
+    setRescheduleOption(option);
+    if (option === "custom" && eventItem) {
+      setCustomReschedule(formatToLocalISOString(newDate(eventItem.start)));
+    }
+  };
+
+  const handleSubmitFeedback = async () => {
+    if (!eventItem) return;
+    setIsSubmittingFeedback(true);
+    try {
+      let rescheduledStart: Date | null = null;
+      if (rescheduleOption === "1h") {
+        rescheduledStart = addHours(newDate(eventItem.start), 1);
+      } else if (rescheduleOption === "3h") {
+        rescheduledStart = addHours(newDate(eventItem.start), 3);
+      } else if (rescheduleOption === "1d") {
+        rescheduledStart = addDays(newDate(eventItem.start), 1);
+      } else if (rescheduleOption === "custom") {
+        if (!customReschedule) {
+          toast.error("Bitte wähle einen neuen Zeitpunkt.");
+          setIsSubmittingFeedback(false);
+          return;
+        }
+        rescheduledStart = newDate(customReschedule);
+      }
+
+      let rescheduledEnd: Date | null = null;
+      if (rescheduledStart) {
+        const duration = eventDurationMinutes;
+        rescheduledEnd = new Date(
+          rescheduledStart.getTime() + duration * 60000
+        );
+        const sourceEventId =
+          eventItem.extendedProps?.sourceEventId ?? eventItem.id;
+        const updates: Partial<CalendarEvent> = {
+          start: rescheduledStart,
+          end: rescheduledEnd,
+        };
+        if (eventItem.allDay) {
+          updates.allDay = true;
+        }
+        await updateEvent(sourceEventId, updates, "single");
+      }
+
+      recordEventMissed(
+        eventItem,
+        feedbackText,
+        rescheduledStart
+      );
+
+      toast.success("Feedback gespeichert", {
+        description: rescheduledStart
+          ? `Termin verschoben auf ${format(
+              rescheduledStart,
+              eventItem.allDay ? "PP" : "PPp"
+            )}.`
+          : "Danke für dein Feedback!",
+      });
+      setFeedbackOpen(false);
+    } catch (error) {
+      console.error("Failed to record event feedback", error);
+      toast.error("Feedback konnte nicht gespeichert werden", {
+        description: "Bitte versuche es erneut.",
+      });
+    } finally {
+      setIsSubmittingFeedback(false);
+    }
+  };
+
   return (
-    <Popover open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <PopoverTrigger asChild>
-        <div
-          className="w-0 h-0 opacity-0 pointer-events-none"
-          style={{
-            position: 'fixed',
-            left: referenceElement ? referenceElement.getBoundingClientRect().left : 0,
-            top: referenceElement ? referenceElement.getBoundingClientRect().top : 0,
-          }}
-        />
-      </PopoverTrigger>
-      <PopoverContent
-        className="z-[10000] w-80 rounded-lg border border-border bg-background p-4 shadow-lg"
-        align="start"
-        sideOffset={24}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        forceMount
-      >
-        <div className="space-y-3">
-          <div className="flex items-start justify-between gap-2">
-            <h3 className="event-title flex items-center gap-2 font-medium text-foreground">
-              {item.title}
-              {isTask ? (
+    <>
+      <Dialog open={feedbackOpen} onOpenChange={setFeedbackOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Termin nicht geschafft?</DialogTitle>
+            <DialogDescription>
+              Teile kurz dein Feedback und plane bei Bedarf sofort einen neuen
+              Zeitpunkt.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="event-feedback">Feedback</Label>
+              <Textarea
+                id="event-feedback"
+                value={feedbackText}
+                onChange={(event) => setFeedbackText(event.target.value)}
+                placeholder="Was hat dich aufgehalten?"
+                rows={3}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Neu planen</Label>
+              <div className="flex flex-wrap gap-2">
+                {RESCHEDULE_CHOICES.map((choice) => (
+                  <Button
+                    key={choice.value}
+                    type="button"
+                    variant={
+                      rescheduleOption === choice.value ? "default" : "outline"
+                    }
+                    size="sm"
+                    onClick={() => handleRescheduleSelection(choice.value)}
+                  >
+                    {choice.label}
+                  </Button>
+                ))}
+              </div>
+              {rescheduleOption === "custom" && (
+                <Input
+                  type="datetime-local"
+                  value={customReschedule}
+                  onChange={(event) => setCustomReschedule(event.target.value)}
+                />
+              )}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setFeedbackOpen(false)}
+              disabled={isSubmittingFeedback}
+            >
+              Abbrechen
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSubmitFeedback}
+              disabled={
+                isSubmittingFeedback ||
+                (rescheduleOption === "custom" && !customReschedule)
+              }
+            >
+              {isSubmittingFeedback ? "Speichern..." : "Feedback senden"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Popover open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <PopoverTrigger asChild>
+          <div
+            className="w-0 h-0 opacity-0 pointer-events-none"
+            style={{
+              position: "fixed",
+              left: referenceElement
+                ? referenceElement.getBoundingClientRect().left
+                : 0,
+              top: referenceElement
+                ? referenceElement.getBoundingClientRect().top
+                : 0,
+            }}
+          />
+        </PopoverTrigger>
+        <PopoverContent
+          className="z-[10000] w-80 rounded-lg border border-border bg-background p-4 shadow-lg"
+          align="start"
+          sideOffset={24}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          forceMount
+        >
+          <div className="space-y-3">
+            <div className="flex items-start justify-between gap-2">
+              <h3 className="event-title flex items-center gap-2 font-medium text-foreground">
+                {item.title}
+                {isTask ? (
                 <>
                   {taskItem?.isRecurring && (
                     <IoRepeat
@@ -186,29 +409,44 @@ export function EventQuickView({
                 </button>
               )}
               {!isTask && eventItem && !isPreparationReminder && (
-                <button
-                  onClick={() => {
-                    if (hasClaimedReward) return;
-                    const summary = awardEventCompletion(eventItem);
-                    showXpToast(summary);
-                    mapEventToSample(eventItem);
-                    setHasClaimedReward(true);
-                  }}
-                  className={cn(
-                    "rounded-md p-1.5",
-                    hasClaimedReward
-                      ? "cursor-not-allowed bg-muted text-muted-foreground"
-                      : "text-muted-foreground hover:bg-muted hover:text-green-600"
-                  )}
-                  title={
-                    hasClaimedReward
-                      ? "Belohnung bereits eingesammelt"
-                      : "Belohnung einsammeln"
-                  }
-                  disabled={hasClaimedReward}
-                >
-                  <HiCheck className="h-4 w-4" />
-                </button>
+                <>
+                  <button
+                    onClick={() => {
+                      const summary = awardEventCompletion(eventItem);
+                      if (!summary) {
+                        toast.info("Belohnung bereits eingesammelt.");
+                        return;
+                      }
+                      showXpToast(summary);
+                      mapEventToSample(eventItem);
+                    }}
+                    className={cn(
+                      "rounded-md p-1.5",
+                      hasClaimedReward
+                        ? "cursor-not-allowed bg-muted text-muted-foreground"
+                        : "text-muted-foreground hover:bg-muted hover:text-green-600"
+                    )}
+                    title={
+                      hasClaimedReward
+                        ? "Belohnung bereits eingesammelt"
+                        : "Belohnung einsammeln"
+                    }
+                    disabled={hasClaimedReward}
+                  >
+                    <HiCheck className="h-4 w-4" />
+                  </button>
+                  <button
+                    onClick={() => {
+                      setRescheduleOption("none");
+                      setCustomReschedule("");
+                      setFeedbackOpen(true);
+                    }}
+                    className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    title="Feedback geben"
+                  >
+                    <HiX className="h-4 w-4" />
+                  </button>
+                </>
               )}
               <button
                 onClick={onEdit}
@@ -452,7 +690,8 @@ export function EventQuickView({
             </div>
           )}
         </div>
-      </PopoverContent>
-    </Popover>
+        </PopoverContent>
+      </Popover>
+    </>
   );
 }

--- a/src/store/focusMode.ts
+++ b/src/store/focusMode.ts
@@ -221,7 +221,9 @@ export const useFocusModeStore = create<FocusModeStore>()(
               const summary = useStatsStore
                 .getState()
                 .awardTaskCompletion(updatedTask);
-              showXpToast(summary);
+              if (summary) {
+                showXpToast(summary);
+              }
             }
 
             // Show celebration overlay

--- a/src/store/stats.ts
+++ b/src/store/stats.ts
@@ -27,6 +27,14 @@ import {
 } from "@/types/stats";
 import { CalendarEvent } from "@/types/calendar";
 
+export interface MissedActivityRecord {
+  id: string;
+  label: string;
+  at: string;
+  feedback?: string;
+  rescheduledTo?: string | null;
+}
+
 interface StatsState {
   level: number;
   currentXp: number;
@@ -44,8 +52,13 @@ interface StatsState {
   activeProfileId: string;
   profiles: Record<string, StatsProfile>;
 
-  awardTaskCompletion: (task: Task) => GainSummary;
-  awardEventCompletion: (event: CalendarEvent) => GainSummary;
+  awardedTaskIds: Record<string, string>;
+  awardedEventIds: Record<string, string>;
+  missedTasks: Record<string, MissedActivityRecord>;
+  missedEvents: Record<string, MissedActivityRecord>;
+
+  awardTaskCompletion: (task: Task) => GainSummary | null;
+  awardEventCompletion: (event: CalendarEvent) => GainSummary | null;
   completeDailyActivity: (activityId: string) => GainSummary | null;
   awardManualXp: (
     amount: number,
@@ -59,6 +72,16 @@ interface StatsState {
   finalizeAvatar: (avatarId: string) => void;
   unlockAvatar: (avatarId: string) => void;
   switchProfile: (userId?: string | null) => void;
+  recordTaskMissed: (
+    task: Task,
+    feedback?: string,
+    rescheduledTo?: Date | null
+  ) => void;
+  recordEventMissed: (
+    event: CalendarEvent,
+    feedback?: string,
+    rescheduledTo?: Date | null
+  ) => void;
 }
 
 const INITIAL_STATS: Record<StatKey, number> = {
@@ -86,12 +109,26 @@ type StatsProfile = {
   avatarId: string;
   unlockedAvatarIds: string[];
   avatarFinalized: boolean;
+  awardedTaskIds: Record<string, string>;
+  awardedEventIds: Record<string, string>;
+  missedTasks: Record<string, MissedActivityRecord>;
+  missedEvents: Record<string, MissedActivityRecord>;
 };
 
 const DEFAULT_PROFILE_KEY = "__local__";
 
-function createDefaultProfile(): StatsProfile {
+function ensureProfileDefaults(profile: StatsProfile): StatsProfile {
   return {
+    ...profile,
+    awardedTaskIds: profile.awardedTaskIds ?? {},
+    awardedEventIds: profile.awardedEventIds ?? {},
+    missedTasks: profile.missedTasks ?? {},
+    missedEvents: profile.missedEvents ?? {},
+  };
+}
+
+function createDefaultProfile(): StatsProfile {
+  return ensureProfileDefaults({
     level: 1,
     currentXp: 0,
     xpForNextLevel: getXpForLevel(1),
@@ -105,39 +142,55 @@ function createDefaultProfile(): StatsProfile {
     avatarId: DEFAULT_AVATAR_ID,
     unlockedAvatarIds: [...INITIAL_UNLOCKED_AVATARS],
     avatarFinalized: false,
-  };
+    awardedTaskIds: {},
+    awardedEventIds: {},
+    missedTasks: {},
+    missedEvents: {},
+  });
 }
 
 function cloneProfile(profile: StatsProfile): StatsProfile {
+  const normalized = ensureProfileDefaults(profile);
   return {
-    ...profile,
-    stats: { ...profile.stats },
-    history: profile.history.map((entry) => ({ ...entry })),
+    ...normalized,
+    stats: { ...normalized.stats },
+    history: normalized.history.map((entry) => ({ ...entry })),
     completedDailyActivities: Object.fromEntries(
-      Object.entries(profile.completedDailyActivities).map(([key, value]) => [
-        key,
-        [...value],
-      ])
+      Object.entries(normalized.completedDailyActivities).map(
+        ([key, value]) => [
+          key,
+          [...value],
+        ]
+      )
     ),
-    unlockedAvatarIds: [...profile.unlockedAvatarIds],
+    unlockedAvatarIds: [...normalized.unlockedAvatarIds],
+    awardedTaskIds: { ...normalized.awardedTaskIds },
+    awardedEventIds: { ...normalized.awardedEventIds },
+    missedTasks: { ...normalized.missedTasks },
+    missedEvents: { ...normalized.missedEvents },
   };
 }
 
 function projectProfile(profile: StatsProfile) {
+  const normalized = ensureProfileDefaults(profile);
   return {
-    level: profile.level,
-    currentXp: profile.currentXp,
-    xpForNextLevel: profile.xpForNextLevel,
-    lifetimeXp: profile.lifetimeXp,
-    stats: profile.stats,
-    history: profile.history,
-    completedDailyActivities: profile.completedDailyActivities,
-    lastProgressDate: profile.lastProgressDate,
-    currentStreak: profile.currentStreak,
-    longestStreak: profile.longestStreak,
-    avatarId: profile.avatarId,
-    unlockedAvatarIds: profile.unlockedAvatarIds,
-    avatarFinalized: profile.avatarFinalized,
+    level: normalized.level,
+    currentXp: normalized.currentXp,
+    xpForNextLevel: normalized.xpForNextLevel,
+    lifetimeXp: normalized.lifetimeXp,
+    stats: normalized.stats,
+    history: normalized.history,
+    completedDailyActivities: normalized.completedDailyActivities,
+    lastProgressDate: normalized.lastProgressDate,
+    currentStreak: normalized.currentStreak,
+    longestStreak: normalized.longestStreak,
+    avatarId: normalized.avatarId,
+    unlockedAvatarIds: normalized.unlockedAvatarIds,
+    avatarFinalized: normalized.avatarFinalized,
+    awardedTaskIds: normalized.awardedTaskIds,
+    awardedEventIds: normalized.awardedEventIds,
+    missedTasks: normalized.missedTasks,
+    missedEvents: normalized.missedEvents,
   };
 }
 
@@ -162,6 +215,24 @@ function pruneDailyRecords(
   if (entries.length <= keepDays) return records;
   const trimmed = entries.slice(entries.length - keepDays);
   return Object.fromEntries(trimmed);
+}
+
+function addMissedRecord(
+  records: Record<string, MissedActivityRecord>,
+  record: MissedActivityRecord,
+  limit = 50
+): Record<string, MissedActivityRecord> {
+  const next = { ...records, [record.id]: record };
+  const sorted = Object.values(next).sort((a, b) =>
+    b.at.localeCompare(a.at)
+  );
+  return sorted.slice(0, limit).reduce<Record<string, MissedActivityRecord>>(
+    (acc, entry) => {
+      acc[entry.id] = entry;
+      return acc;
+    },
+    {}
+  );
 }
 
 function calculateTaskXp(task: Task): number {
@@ -312,6 +383,18 @@ function findActivityForToday(
   todayActivities: DailyActivityDefinition[]
 ): DailyActivityDefinition | undefined {
   return todayActivities.find((activity) => activity.id === activityId);
+}
+
+export function getTaskRewardKey(task: Task): string {
+  return task.id;
+}
+
+export function getEventRewardKey(event: CalendarEvent): string {
+  const sourceId = event.extendedProps?.sourceEventId;
+  if (typeof sourceId === "string" && sourceId.trim().length > 0) {
+    return sourceId;
+  }
+  return event.id;
 }
 
 export const useStatsStore = create<StatsState>()(
@@ -465,6 +548,10 @@ export const useStatsStore = create<StatsState>()(
         },
 
         awardTaskCompletion: (task) => {
+          const rewardKey = getTaskRewardKey(task);
+          if (rewardKey && get().awardedTaskIds[rewardKey]) {
+            return null;
+          }
           const statKey = inferStatFromTask(task);
           const statAmount = getStatGainForTask(task);
           const statChanges: StatChange[] = [
@@ -475,16 +562,33 @@ export const useStatsStore = create<StatsState>()(
             statChanges.push(...tagResult.statChanges);
           }
           const xp = calculateTaskXp(task) + tagResult.xpBonus;
-          return recordGain(
+          const summary = recordGain(
             xp,
             task.title,
             "task",
             statChanges,
             tagResult.hypeText
           );
+          mutateActiveProfile((profile) => {
+            profile.awardedTaskIds = {
+              ...profile.awardedTaskIds,
+              [rewardKey]: newDate().toISOString(),
+            };
+            if (profile.missedTasks[rewardKey]) {
+              const updatedMissed = { ...profile.missedTasks };
+              delete updatedMissed[rewardKey];
+              profile.missedTasks = updatedMissed;
+            }
+            return profile;
+          });
+          return summary;
         },
 
         awardEventCompletion: (event) => {
+          const rewardKey = getEventRewardKey(event);
+          if (rewardKey && get().awardedEventIds[rewardKey]) {
+            return null;
+          }
           const start = newDate(event.start);
           const end = event.end ? newDate(event.end) : newDate(event.start);
           let durationMinutes = Math.max(
@@ -518,13 +622,26 @@ export const useStatsStore = create<StatsState>()(
           const xp = baseXp + tagResult.xpBonus;
           const label = event.title || "Kalendereintrag";
 
-          return recordGain(
+          const summary = recordGain(
             xp,
             label,
             "event",
             statChanges,
             tagResult.hypeText
           );
+          mutateActiveProfile((profile) => {
+            profile.awardedEventIds = {
+              ...profile.awardedEventIds,
+              [rewardKey]: newDate().toISOString(),
+            };
+            if (profile.missedEvents[rewardKey]) {
+              const updatedMissed = { ...profile.missedEvents };
+              delete updatedMissed[rewardKey];
+              profile.missedEvents = updatedMissed;
+            }
+            return profile;
+          });
+          return summary;
         },
 
         completeDailyActivity: (activityId) => {
@@ -571,6 +688,48 @@ export const useStatsStore = create<StatsState>()(
             statChanges.push(change);
           }
           return recordGain(amount, label, "manual", statChanges);
+        },
+
+        recordTaskMissed: (task, feedback, rescheduledTo) => {
+          const rewardKey = getTaskRewardKey(task);
+          const timestamp = newDate().toISOString();
+          const trimmedFeedback = feedback?.trim();
+          mutateActiveProfile((profile) => {
+            profile.missedTasks = addMissedRecord(profile.missedTasks, {
+              id: rewardKey,
+              label: task.title,
+              at: timestamp,
+              feedback:
+                trimmedFeedback && trimmedFeedback.length > 0
+                  ? trimmedFeedback
+                  : undefined,
+              rescheduledTo: rescheduledTo
+                ? rescheduledTo.toISOString()
+                : null,
+            });
+            return profile;
+          });
+        },
+
+        recordEventMissed: (event, feedback, rescheduledTo) => {
+          const rewardKey = getEventRewardKey(event);
+          const timestamp = newDate().toISOString();
+          const trimmedFeedback = feedback?.trim();
+          mutateActiveProfile((profile) => {
+            profile.missedEvents = addMissedRecord(profile.missedEvents, {
+              id: rewardKey,
+              label: event.title || "Kalendereintrag",
+              at: timestamp,
+              feedback:
+                trimmedFeedback && trimmedFeedback.length > 0
+                  ? trimmedFeedback
+                  : undefined,
+              rescheduledTo: rescheduledTo
+                ? rescheduledTo.toISOString()
+                : null,
+            });
+            return profile;
+          });
         },
 
         resetDailyCompletion: (date) => {
@@ -646,7 +805,7 @@ export const useStatsStore = create<StatsState>()(
       },
     {
       name: "stats-store",
-      version: 4,
+      version: 5,
       migrate: async (persistedState, version) => {
         if (!persistedState || typeof persistedState !== "object") {
           return persistedState as StatsState;
@@ -658,6 +817,24 @@ export const useStatsStore = create<StatsState>()(
 
         if (version < 3) {
           draft.avatarFinalized = draft.avatarFinalized ?? false;
+        }
+
+        if (version < 5) {
+          draft.awardedTaskIds = draft.awardedTaskIds ?? {};
+          draft.awardedEventIds = draft.awardedEventIds ?? {};
+          draft.missedTasks = draft.missedTasks ?? {};
+          draft.missedEvents = draft.missedEvents ?? {};
+          if (draft.profiles) {
+            Object.entries(draft.profiles).forEach(([key, profile]) => {
+              draft.profiles![key] = ensureProfileDefaults({
+                ...profile,
+                awardedTaskIds: profile.awardedTaskIds ?? {},
+                awardedEventIds: profile.awardedEventIds ?? {},
+                missedTasks: profile.missedTasks ?? {},
+                missedEvents: profile.missedEvents ?? {},
+              });
+            });
+          }
         }
 
         if (!draft.profiles) {


### PR DESCRIPTION
## Summary
- track claimed XP rewards and missed activities per profile to block duplicate XP grants for tasks and events
- guard task completion flows against double toasts and expose APIs for recording failed attempts
- add an event feedback dialog that lets users report a missed appointment and optionally reschedule it directly from the quick view

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e826616c9883318dfbe6a0ce7e135f